### PR TITLE
[1.3] Sanitize the output when writing the logging.properties file.

### DIFF
--- a/src/main/java/org/jboss/logmanager/PropertyConfigurator.java
+++ b/src/main/java/org/jboss/logmanager/PropertyConfigurator.java
@@ -211,6 +211,10 @@ public final class PropertyConfigurator implements Configurator {
             if (level != null) {
                 writeProperty(out, prefix, "level", level);
             }
+            final String encoding = handler.getEncoding();
+            if (encoding != null) {
+                writeProperty(out, prefix, "encoding", encoding);
+            }
             final String filter = handler.getFilter();
             if (filter != null) {
                 writeProperty(out, prefix, "filter", filter);
@@ -430,7 +434,8 @@ public final class PropertyConfigurator implements Configurator {
         final String filterName = getStringProperty(properties, getKey("logger", loggerName, "filter"));
         if (filterName != null) {
             loggerConfiguration.setFilter(filterName);
-            configureFilter(properties, filterName);
+            // TODO (jrp) doesn't work LOGMGR-51
+            // configureFilter(properties, filterName);
         }
 
         // Get logger handlers


### PR DESCRIPTION
Ensure the keys and values are written out as the properties specification says.
