### PR TITLE
[LOGMGR-44] Allow . (dots) in logger namespace, but only if the parent is not null

### DIFF
--- a/src/main/java/org/jboss/logmanager/LoggerNode.java
+++ b/src/main/java/org/jboss/logmanager/LoggerNode.java
@@ -124,13 +124,17 @@ final class LoggerNode {
      */
     private LoggerNode(LogContext context, LoggerNode parent, String nodeName) {
         nodeName = nodeName.trim();
-        if (nodeName.length() == 0) {
-            throw new IllegalArgumentException("nodeName is empty, or just whitespace");
+        if (nodeName.length() == 0 && parent == null) {
+            throw new IllegalArgumentException("nodeName is empty, or just whitespace and has no parent");
         }
         this.parent = parent;
         handlersUpdater.clear(this);
         if (parent.parent == null) {
-            fullName = nodeName;
+            if (nodeName.isEmpty()) {
+                fullName = ".";
+            } else {
+                fullName = nodeName;
+            }
         } else {
             fullName = parent.fullName + "." + nodeName;
         }

--- a/src/test/java/org/jboss/logmanager/LoggerTests.java
+++ b/src/test/java/org/jboss/logmanager/LoggerTests.java
@@ -42,6 +42,14 @@ public final class LoggerTests {
     }
 
     @Test
+    public void testCategories() {
+        assertNotNull("Logger not created with category: " + LoggerTests.class.getName(), Logger.getLogger(LoggerTests.class.getName()));
+        assertNotNull("Logger not created with category: Spaced Logger Name", Logger.getLogger("Spaced Logger Name"));
+        assertNotNull("Logger not created with category: /../Weird/Path", Logger.getLogger("/../Weird/Path"));
+        assertNotNull("Logger not created with category: random.chars.`~!@#$%^&*()-=_+[]{}\\|;':\",.<>/?", Logger.getLogger("random.chars.`~!@#$%^&*()-=_+[]{}\\|;':\",.<>/?"));
+    }
+
+    @Test
     public void testHandlerAdd() {
         final NullHandler h1 = new NullHandler();
         final NullHandler h2 = new NullHandler();

--- a/src/test/resources/org/jboss/logmanager/default-logging.properties
+++ b/src/test/resources/org/jboss/logmanager/default-logging.properties
@@ -19,7 +19,7 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 #
-loggers=org.jboss.logmanager,Spaced\\Logger,Special:Char\\Logger,org.jboss.filter1,org.jboss.filter2
+loggers=org.jboss.logmanager,Spaced\\Logger,Special:Char\\Logger,org.jboss.filter1,org.jboss.filter2,/../Weird/Path
 
 # Root logger
 logger.level=INFO
@@ -36,6 +36,8 @@ logger.Special\:Char\\Logger.level=INFO
 
 logger.org.jboss.filter1.filter=match(".*")
 logger.org.jboss.filter2.filter=FILTER
+
+logger./../Weird/Path.level=INFO
 
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
 handler.CONSOLE.formatter=PATTERN


### PR DESCRIPTION
Category names (namespaces) with `.` (dots) should be allowed. This allows for empty names, given that a dot is a delimiter for the category, as long as the parent logger isn't `null`.
