### PR TITLE
[LOGMGR-75] Trim values for known types from logging.properties

### DIFF
--- a/src/main/java/org/jboss/logmanager/PropertyConfigurator.java
+++ b/src/main/java/org/jboss/logmanager/PropertyConfigurator.java
@@ -491,6 +491,22 @@ public final class PropertyConfigurator implements Configurator {
 
     /**
      * Configure the log manager from the given properties.
+     * <p/>
+     * The following values read in from a configuration will be trimmed of prefixed and trailing whitespace:
+     * <pre>
+     *     <ul>
+     *         <li>logger.NAME.filter</li>
+     *         <li>logger.NAME.level</li>
+     *         <li>logger.NAME.useParentHandlers</li>
+     *         <li>handler.NAME.filter</li>
+     *         <li>handler.NAME.formatter</li>
+     *         <li>handler.NAME.level</li>
+     *         <li>handler.NAME.encoding</li>
+     *         <li>handler.NAME.errorManager</li>
+     *     </ul>
+     * </pre>
+     *
+     * If the values are {@link #writeConfiguration(java.io.OutputStream) written} the trimmed values will be written for the above properties.
      *
      * @param properties the properties
      * @throws IOException if an error occurs
@@ -730,7 +746,7 @@ public final class PropertyConfigurator implements Configurator {
     private void configureProperties(final Properties properties, final PropertyConfigurable configurable, final String prefix) {
         final List<String> propertyNames = getStringCsvList(properties, getKey(prefix, "properties"));
         for (String propertyName : propertyNames) {
-            final String valueString = getStringProperty(properties, getKey(prefix, propertyName));
+            final String valueString = getStringProperty(properties, getKey(prefix, propertyName), false);
             if (valueString != null) configurable.setPropertyValueString(propertyName, valueString);
         }
     }
@@ -744,7 +760,12 @@ public final class PropertyConfigurator implements Configurator {
     }
 
     private static String getStringProperty(final Properties properties, final String key) {
-        return properties.getProperty(key);
+        return getStringProperty(properties, key, true);
+    }
+
+    private static String getStringProperty(final Properties properties, final String key, final boolean trim) {
+        final String value = properties.getProperty(key);
+        return (trim ? (value == null ? null : value.trim()) : value);
     }
 
     private static String[] getStringCsvArray(final Properties properties, final String key) {

--- a/src/main/java/org/jboss/logmanager/config/LogContextConfigurationImpl.java
+++ b/src/main/java/org/jboss/logmanager/config/LogContextConfigurationImpl.java
@@ -401,66 +401,68 @@ final class LogContextConfigurationImpl implements LogContextConfiguration {
             }
             return ObjectProducer.NULL_PRODUCER;
         }
-        final String replaced = valueExpression.getResolvedValue();
+        final String resolvedValue = valueExpression.getResolvedValue();
+        final String trimmedValue = resolvedValue.trim();
         if (paramType == String.class) {
-            return new SimpleObjectProducer(replaced);
+            // Don't use the trimmed value for strings
+            return new SimpleObjectProducer(resolvedValue);
         } else if (paramType == Handler.class) {
-            if (! handlers.containsKey(replaced) || immediate && ! handlerRefs.containsKey(replaced)) {
-                throw new IllegalArgumentException(String.format("No handler named \"%s\" is defined", replaced));
+            if (! handlers.containsKey(trimmedValue) || immediate && ! handlerRefs.containsKey(trimmedValue)) {
+                throw new IllegalArgumentException(String.format("No handler named \"%s\" is defined", trimmedValue));
             }
             if (immediate) {
-                return new SimpleObjectProducer(handlerRefs.get(replaced));
+                return new SimpleObjectProducer(handlerRefs.get(trimmedValue));
             } else {
-                return new RefProducer(replaced, handlerRefs);
+                return new RefProducer(trimmedValue, handlerRefs);
             }
         } else if (paramType == Filter.class) {
-            return resolveFilter(replaced, immediate);
+            return resolveFilter(trimmedValue, immediate);
         } else if (paramType == Formatter.class) {
-            if (! formatters.containsKey(replaced) || immediate && ! formatterRefs.containsKey(replaced)) {
-                throw new IllegalArgumentException(String.format("No formatter named \"%s\" is defined", replaced));
+            if (! formatters.containsKey(trimmedValue) || immediate && ! formatterRefs.containsKey(trimmedValue)) {
+                throw new IllegalArgumentException(String.format("No formatter named \"%s\" is defined", trimmedValue));
             }
             if (immediate) {
-                return new SimpleObjectProducer(formatterRefs.get(replaced));
+                return new SimpleObjectProducer(formatterRefs.get(trimmedValue));
             } else {
-                return new RefProducer(replaced, formatterRefs);
+                return new RefProducer(trimmedValue, formatterRefs);
             }
         } else if (paramType == ErrorManager.class) {
-            if (! errorManagers.containsKey(replaced) || immediate && ! errorManagerRefs.containsKey(replaced)) {
-                throw new IllegalArgumentException(String.format("No error manager named \"%s\" is defined", replaced));
+            if (! errorManagers.containsKey(trimmedValue) || immediate && ! errorManagerRefs.containsKey(trimmedValue)) {
+                throw new IllegalArgumentException(String.format("No error manager named \"%s\" is defined", trimmedValue));
             }
             if (immediate) {
-                return new SimpleObjectProducer(errorManagerRefs.get(replaced));
+                return new SimpleObjectProducer(errorManagerRefs.get(trimmedValue));
             } else {
-                return new RefProducer(replaced, errorManagerRefs);
+                return new RefProducer(trimmedValue, errorManagerRefs);
             }
         } else if (paramType == java.util.logging.Level.class) {
-            return new SimpleObjectProducer(LogContext.getSystemLogContext().getLevelForName(replaced));
+            return new SimpleObjectProducer(LogContext.getSystemLogContext().getLevelForName(trimmedValue));
         } else if (paramType == java.util.logging.Logger.class) {
-            return new SimpleObjectProducer(LogContext.getSystemLogContext().getLogger(replaced));
+            return new SimpleObjectProducer(LogContext.getSystemLogContext().getLogger(trimmedValue));
         } else if (paramType == boolean.class || paramType == Boolean.class) {
-            return new SimpleObjectProducer(Boolean.valueOf(replaced));
+            return new SimpleObjectProducer(Boolean.valueOf(trimmedValue));
         } else if (paramType == byte.class || paramType == Byte.class) {
-            return new SimpleObjectProducer(Byte.valueOf(replaced));
+            return new SimpleObjectProducer(Byte.valueOf(trimmedValue));
         } else if (paramType == short.class || paramType == Short.class) {
-            return new SimpleObjectProducer(Short.valueOf(replaced));
+            return new SimpleObjectProducer(Short.valueOf(trimmedValue));
         } else if (paramType == int.class || paramType == Integer.class) {
-            return new SimpleObjectProducer(Integer.valueOf(replaced));
+            return new SimpleObjectProducer(Integer.valueOf(trimmedValue));
         } else if (paramType == long.class || paramType == Long.class) {
-            return new SimpleObjectProducer(Long.valueOf(replaced));
+            return new SimpleObjectProducer(Long.valueOf(trimmedValue));
         } else if (paramType == float.class || paramType == Float.class) {
-            return new SimpleObjectProducer(Float.valueOf(replaced));
+            return new SimpleObjectProducer(Float.valueOf(trimmedValue));
         } else if (paramType == double.class || paramType == Double.class) {
-            return new SimpleObjectProducer(Double.valueOf(replaced));
+            return new SimpleObjectProducer(Double.valueOf(trimmedValue));
         } else if (paramType == char.class || paramType == Character.class) {
-            return new SimpleObjectProducer(Character.valueOf(replaced.length() > 0 ? replaced.charAt(0) : 0));
+            return new SimpleObjectProducer(Character.valueOf(trimmedValue.length() > 0 ? trimmedValue.charAt(0) : 0));
         } else if (paramType == TimeZone.class) {
-            return new SimpleObjectProducer(TimeZone.getTimeZone(replaced));
+            return new SimpleObjectProducer(TimeZone.getTimeZone(trimmedValue));
         } else if (paramType == Charset.class) {
-            return new SimpleObjectProducer(Charset.forName(replaced));
+            return new SimpleObjectProducer(Charset.forName(trimmedValue));
         } else if (paramType.isEnum()) {
-            return new SimpleObjectProducer(Enum.valueOf(paramType.asSubclass(Enum.class), replaced));
-        } else if (pojos.containsKey(replaced)) {
-            return new RefProducer(replaced, pojoRefs);
+            return new SimpleObjectProducer(Enum.valueOf(paramType.asSubclass(Enum.class), trimmedValue));
+        } else if (pojos.containsKey(trimmedValue)) {
+            return new RefProducer(trimmedValue, pojoRefs);
         } else {
             throw new IllegalArgumentException("Unknown parameter type for property " + propertyName + " on " + objClass);
         }

--- a/src/test/java/org/jboss/logmanager/PropertyConfiguratorTests.java
+++ b/src/test/java/org/jboss/logmanager/PropertyConfiguratorTests.java
@@ -249,6 +249,33 @@ public class PropertyConfiguratorTests {
 
     }
 
+    @Test
+    public void testSpacedProperties() throws Exception {
+        final Properties defaultProperties = new Properties();
+        defaultProperties.load(PropertyConfiguratorTests.class.getResourceAsStream("spaced-value-logging.properties"));
+        final LogContext logContext = LogContext.create();
+        final PropertyConfigurator configurator = new PropertyConfigurator(logContext);
+        configurator.configure(defaultProperties);
+
+        // Load the expected properties, all values should be trimmed with the exception of type.NAME.properties
+        final Properties expectedProperties = new Properties();
+        expectedProperties.load(PropertyConfiguratorTests.class.getResourceAsStream("expected-spaced-value-logging.properties"));
+
+        // Write out the configuration
+        final ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+        expectedProperties.store(new OutputStreamWriter(propsOut, "utf-8"), null);
+        final ByteArrayOutputStream configOut = new ByteArrayOutputStream();
+        configurator.writeConfiguration(configOut);
+
+        // Reload output streams into properties
+        final Properties configProps = new Properties();
+        final ByteArrayInputStream configIn = new ByteArrayInputStream(configOut.toByteArray());
+        configProps.load(new InputStreamReader(configIn, "utf-8"));
+        final Properties dftProps = new Properties();
+        dftProps.load(new InputStreamReader(new ByteArrayInputStream(propsOut.toByteArray()), "utf-8"));
+        compare(dftProps, configProps);
+    }
+
     // TODO (jrp) Note that in the future this test could break as a handler really shouldn't be allowed to be removed if it's attached to a logger
     @Test
     public void testWriteInvalidConfig() throws Exception {

--- a/src/test/resources/org/jboss/logmanager/expected-spaced-value-logging.properties
+++ b/src/test/resources/org/jboss/logmanager/expected-spaced-value-logging.properties
@@ -1,0 +1,57 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2013, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+loggers=org.jboss.logmanager
+
+# Root logger
+logger.level=INFO
+logger.handlers=CONSOLE
+
+logger.org.jboss.logmanager.filter=any(accept)
+logger.org.jboss.logmanager.useParentHandlers=true
+logger.org.jboss.logmanager.level=INFO
+
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.formatter=PATTERN
+handler.CONSOLE.properties=autoFlush,target
+handler.CONSOLE.autoFlush=\u0020true\u0020
+handler.CONSOLE.target=\u0020SYSTEM_OUT
+handler.CONSOLE.filter=FILTER
+handler.CONSOLE.encoding=UTF-8
+handler.CONSOLE.errorManager=DFT
+
+filter.FILTER=org.jboss.logmanager.AcceptFilter
+
+errorManager.DFT=org.jboss.logmanager.errormanager.OnlyOnceErrorManager
+
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern='\u0020'%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n
+
+pojos=filePojo
+pojo.filePojo=org.jboss.logmanager.TestFileHandler
+pojo.filePojo.properties=autoFlush,append,fileName,encoding
+pojo.filePojo.constructorProperties=fileName,append
+pojo.filePojo.autoFlush=true
+pojo.filePojo.append=false
+pojo.filePojo.fileName=test.log
+pojo.filePojo.encoding=UTF-8
+pojo.filePojo.postConfiguration=flush

--- a/src/test/resources/org/jboss/logmanager/spaced-value-logging.properties
+++ b/src/test/resources/org/jboss/logmanager/spaced-value-logging.properties
@@ -1,0 +1,57 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2013, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+loggers=org.jboss.logmanager
+
+# Root logger
+logger.level=\u0020INFO
+logger.handlers=CONSOLE
+
+logger.org.jboss.logmanager.filter=\u0020any(accept)\u0020
+logger.org.jboss.logmanager.useParentHandlers=true\u0020
+logger.org.jboss.logmanager.level=\u0020INFO\u0020
+
+handler.CONSOLE=\u0020org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.formatter=PATTERN\u0020
+handler.CONSOLE.properties=autoFlush,target
+handler.CONSOLE.autoFlush=\u0020true\u0020
+handler.CONSOLE.target=\u0020SYSTEM_OUT
+handler.CONSOLE.filter=FILTER\u0020
+handler.CONSOLE.encoding=\u0020UTF-8\u0020
+handler.CONSOLE.errorManager=\u0020DFT\u0020
+
+filter.FILTER=org.jboss.logmanager.AcceptFilter
+
+errorManager.DFT=org.jboss.logmanager.errormanager.OnlyOnceErrorManager
+
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern='\u0020'%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n
+
+pojos=filePojo
+pojo.filePojo=org.jboss.logmanager.TestFileHandler
+pojo.filePojo.properties=autoFlush,append,fileName,encoding
+pojo.filePojo.constructorProperties=fileName,append
+pojo.filePojo.autoFlush=true
+pojo.filePojo.append=false
+pojo.filePojo.fileName=test.log
+pojo.filePojo.encoding=UTF-8
+pojo.filePojo.postConfiguration=flush


### PR DESCRIPTION
Trims values from known types; level, filter, formatter, etc, and trims values when converting the string value to an object. For example an enum property value is trimmed before it attempted to be parsed.
