### PR TITLE
[LOGMGR-66] RegexFilter based on a formatted message

### DIFF
--- a/src/main/java/org/jboss/logmanager/filters/RegexFilter.java
+++ b/src/main/java/org/jboss/logmanager/filters/RegexFilter.java
@@ -27,6 +27,8 @@ import java.util.regex.Pattern;
 import java.util.logging.Filter;
 import java.util.logging.LogRecord;
 
+import org.jboss.logmanager.ExtLogRecord;
+
 /**
  * A regular-expression-based filter.  Used to exclude log records which match or don't match the expression.  The
  * regular expression is checked against the raw (unformatted) message.
@@ -59,6 +61,13 @@ public final class RegexFilter implements Filter {
      * @return {@code true} if the log record is loggable
      */
     public boolean isLoggable(final LogRecord record) {
-        return pattern.matcher(record.getMessage()).find();
+        String message = null;
+        if (record instanceof ExtLogRecord) {
+            message = ((ExtLogRecord) record).getFormattedMessage();
+        }
+        if (message == null) {
+            message = record.getMessage();
+        }
+        return pattern.matcher(message).find();
     }
 }

--- a/src/test/java/org/jboss/logmanager/FilterTests.java
+++ b/src/test/java/org/jboss/logmanager/FilterTests.java
@@ -406,6 +406,40 @@ public final class FilterTests {
     }
 
     @Test
+    public void testRegexFilter2() {
+        final Filter filter = new RegexFilter("pest");
+        final AtomicBoolean ran = new AtomicBoolean();
+        final Handler handler = new CheckingHandler(ran);
+        final Logger logger = Logger.getLogger("filterTest");
+        final ExtLogRecord record = new ExtLogRecord(Level.INFO, "This is a test %s", FormatStyle.PRINTF, "filterTest");
+        record.setParameters(new String[] {"pest"});
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        logger.setLevel(Level.INFO);
+        logger.setFilter(filter);
+        handler.setLevel(Level.INFO);
+        logger.log(record);
+        assertTrue("Handler wasn't run", ran.get());
+    }
+
+    @Test
+    public void testRegexFilter3() {
+        final Filter filter = new RegexFilter("pest");
+        final AtomicBoolean ran = new AtomicBoolean();
+        final Handler handler = new CheckingHandler(ran);
+        final Logger logger = Logger.getLogger("filterTest");
+        final ExtLogRecord record = new ExtLogRecord(Level.INFO, "This is a test %s", FormatStyle.PRINTF, "filterTest");
+        record.setParameters(new String[] {"test"});
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        logger.setLevel(Level.INFO);
+        logger.setFilter(filter);
+        handler.setLevel(Level.INFO);
+        logger.log(record);
+        assertFalse("Handler was run", ran.get());
+    }
+
+    @Test
     public void testSubstitueFilter0() {
         final Filter filter = new SubstituteFilter(Pattern.compile("test"), "lunch", true);
         final AtomicReference<String> result = new AtomicReference<String>();


### PR DESCRIPTION
Filtering should be done based on a string the user is seeing.  See https://issues.jboss.org/browse/LOGMGR-66 for details.
