### PR TITLE
SyslogHandler.findPid() omitted the last digit of the pid

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/SyslogHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/SyslogHandler.java
@@ -1042,7 +1042,7 @@ public class SyslogHandler extends ExtHandler {
         final int index = name.indexOf("@");
         if (index > -1) {
             try {
-                result = Integer.toString(Integer.valueOf(name.substring(0, index - 1)));
+                result = Integer.toString(Integer.valueOf(name.substring(0, index)));
             } catch (NumberFormatException ignore) {
                 // ignore
             }


### PR DESCRIPTION
The last digit of the pid omitted.
seems to usage mistake of substring().
see:
![pid](https://f.cloud.github.com/assets/6468155/2342019/4ee5ea16-a4eb-11e3-8843-39d7c0f36f3e.png)
