### PR TITLE
[LOGMGR-104] SyslogHandler doesn't handle multi-byte characters

### DIFF
--- a/src/test/java/org/jboss/logmanager/handlers/SyslogHandlerTests.java
+++ b/src/test/java/org/jboss/logmanager/handlers/SyslogHandlerTests.java
@@ -169,7 +169,7 @@ public class SyslogHandlerTests {
         final Calendar cal = getCalendar();
         // Create the record
         handler.setHostname("test");
-        final String part1 = "This is a longer message and should be truncated after this.";
+        final String part1 = "This is a longer message and should be truncated after this. even with 4 byte UTF-8 charactors too: 𥹖";
         final String part2 = "Truncated portion of the message that will not be shown in.";
         final String message = part1 + " " + part2;
 


### PR DESCRIPTION
As I wrote in LOGMGR-104, I tried to log multi-byte message with both of org.jboss.logmanager.handlers.SyslogHandler and org.apache.log4j.net.SyslogAppender for same message, only SyslogHandler output were corrupted. see:
![syslog](https://f.cloud.github.com/assets/6468155/2365148/1162d88a-a6ac-11e3-96c8-4e04159e28c2.png)

This commit fixes this issue. most of codes were taken from:
http://info.michael-simons.eu/2013/01/21/java-mysql-and-multi-byte-utf-8-support/
