### PR TITLE
PID truncated in Syslog events

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/SyslogHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/SyslogHandler.java
@@ -1038,7 +1038,7 @@ public class SyslogHandler extends ExtHandler {
 
     private static String findPid() {
         final String name = ManagementFactory.getRuntimeMXBean().getName();
-        String result = name;
+        String result = null;
         final int index = name.indexOf("@");
         if (index > -1) {
             try {


### PR DESCRIPTION
The PID sent in Syslog events is truncated, the last digit is always missing.  This fixes it.
