### PR TITLE
[LOGMGR-107] Implement LogManager.getLoggerNames()

### DIFF
--- a/src/main/java/org/jboss/logmanager/LogManager.java
+++ b/src/main/java/org/jboss/logmanager/LogManager.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -561,21 +560,9 @@ public final class LogManager extends java.util.logging.LogManager {
         // no operation!
     }
 
-    /**
-     * Does nothing.  Logger names are not available.
-     *
-     * @return an empty enumeration
-     */
+    @Override
     public Enumeration<String> getLoggerNames() {
-        return new Enumeration<String>() {
-            public boolean hasMoreElements() {
-                return false;
-            }
-
-            public String nextElement() {
-                throw new NoSuchElementException("No elements");
-            }
-        };
+        return LogContext.getLogContext().getLoggerNames();
     }
 
     /**

--- a/src/main/java/org/jboss/logmanager/Logger.java
+++ b/src/main/java/org/jboss/logmanager/Logger.java
@@ -750,4 +750,13 @@ public final class Logger extends java.util.logging.Logger implements Serializab
     public String toString() {
         return "Logger '" + getName() + "' in context " + loggerNode.getContext();
     }
+
+    @Override
+    protected void finalize() throws Throwable {
+        try {
+            loggerNode.decrementRef();
+        } finally {
+            super.finalize();
+        }
+    }
 }

--- a/src/main/java/org/jboss/logmanager/LoggerNode.java
+++ b/src/main/java/org/jboss/logmanager/LoggerNode.java
@@ -201,13 +201,22 @@ final class LoggerNode {
             return AccessController.doPrivileged(new PrivilegedAction<Logger>() {
                 public Logger run() {
                     final Logger logger = new Logger(LoggerNode.this, fullName);
+                    context.incrementRef(fullName);
                     return logger;
                 }
             });
         } else {
             final Logger logger = new Logger(this, fullName);
+            context.incrementRef(fullName);
             return logger;
         }
+    }
+
+    /**
+     * Removes one from the reference count.
+     */
+    void decrementRef() {
+        context.decrementRef(fullName);
     }
 
     /**

--- a/src/test/java/org/jboss/logmanager/AbstractTest.java
+++ b/src/test/java/org/jboss/logmanager/AbstractTest.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.logmanager;
+
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public abstract class AbstractTest {
+
+    @Before
+    public void addLogContext() {
+        final LogContext context = LogContext.create();
+        LogContext.setLogContextSelector(new LogContextSelector() {
+            @Override
+            public LogContext getLogContext() {
+                return context;
+            }
+        });
+    }
+
+    @After
+    public void removeLogContext() {
+        LogContext.setLogContextSelector(LogContext.DEFAULT_LOG_CONTEXT_SELECTOR);
+    }
+}

--- a/src/test/java/org/jboss/logmanager/LogManagerTests.java
+++ b/src/test/java/org/jboss/logmanager/LogManagerTests.java
@@ -23,6 +23,10 @@
 package org.jboss.logmanager;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +34,7 @@ import org.junit.Test;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class LogManagerTests {
+public class LogManagerTests extends AbstractTest {
     static {
         // Access a logger in initialize the logmanager
         java.util.logging.Logger.getAnonymousLogger();
@@ -73,5 +77,26 @@ public class LogManagerTests {
                 Assert.assertEquals(l, level);
             }
         }
+    }
+
+    @Test
+    public void checkLoggerNames() {
+        // Get the log manager
+        final java.util.logging.LogManager logManager = java.util.logging.LogManager.getLogManager();
+        // Should be a org.jboss.logmanager.LogManager
+        Assert.assertEquals(LogManager.class, logManager.getClass());
+
+        final List<String> expectedNames = Arrays.asList("", "test1", "org.jboss", "org.jboss.logmanager", "other", "stdout");
+
+        // Create the loggers
+        for (String name : expectedNames) {
+            Logger.getLogger(name);
+        }
+        compare(expectedNames, Collections.list(logManager.getLoggerNames()));
+    }
+
+    private <T> void compare(final Collection<T> expected, final Collection<T> actual) {
+        Assert.assertTrue("Expected: " + expected.toString() + " Actual: " + actual.toString(), expected.containsAll(actual));
+        Assert.assertTrue("Expected: " + expected.toString() + " Actual: " + actual.toString(), actual.containsAll(expected));
     }
 }


### PR DESCRIPTION
The J.U.L. `LogManager.getLoggerNames()` only returns loggers that have been created. Adding the `boolean` to the `LoggerNode` allows the `org.jboss.logmanager.LogManager.getLoggerNames()` to have the same results.

While in J.U.L the `LogManager.getLoggingMXBean().getLoggerNames()` does _not_ return loggers that have been created, our implementation has always done this. Therefore I decided to leave our implementation as is for now.
