### PR TITLE
Use null to singnal unknown file/class/method name

### DIFF
--- a/src/main/java/org/jboss/logmanager/ExtLogRecord.java
+++ b/src/main/java/org/jboss/logmanager/ExtLogRecord.java
@@ -317,10 +317,10 @@ public class ExtLogRecord extends LogRecord {
     }
 
     private void setUnknownCaller() {
-        setSourceClassName("<unknown>");
-        setSourceMethodName("<unknown>");
+        setSourceClassName(null);
+        setSourceMethodName(null);
         setSourceLineNumber(-1);
-        setSourceFileName("<unknown>");
+        setSourceFileName(null);
     }
 
     /**


### PR DESCRIPTION
`ExtLogRecord` uses undocumented special value to represent _unknown_ log source. According to `java.util.logging.LogRecord` javadoc, `null` should be used for that.
