### PR TITLE
[LOGMGR-118] Print suppressed exceptions in stack trace with options to limit the number of suppressed exceptions printed.

### DIFF
--- a/src/main/java/org/jboss/logmanager/formatters/FormatStringParser.java
+++ b/src/main/java/org/jboss/logmanager/formatters/FormatStringParser.java
@@ -95,11 +95,11 @@ public final class FormatStringParser {
                         break;
                     }
                     case 'e': {
-                        stepList.add(Formatters.exceptionFormatStep(leftJustify, minimumWidth, truncateBeginning, maximumWidth, false));
+                        stepList.add(Formatters.exceptionFormatStep(leftJustify, minimumWidth, truncateBeginning, maximumWidth, argument, false));
                         break;
                     }
                     case 'E': {
-                        stepList.add(Formatters.exceptionFormatStep(leftJustify, minimumWidth, truncateBeginning, maximumWidth, true));
+                        stepList.add(Formatters.exceptionFormatStep(leftJustify, minimumWidth, truncateBeginning, maximumWidth, argument, true));
                         break;
                     }
                     case 'F': {


### PR DESCRIPTION
Currently defaults to printing no suppressed exceptions. You can specify the how many levels of suppressed exceptions can print by specifying the argument, `%e{1}` or `%E{1}`. Any value less than 0 indicates all suppressed messages should be printed.

Suppressed messages print with a `Suppressed: ` prefix. This could optionally be changed to append the number or the class name of the previous expression it was suppressed by.

Example stack trace:
```java
Test: java.lang.RuntimeException: level1
    at org.jboss.logmanager.formatters.PatternFormatterTests.extendedThrowable(PatternFormatterTests.java:196)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:254)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:149)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:159)
    at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:87)
    at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
    at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:95)
    Suppressed: java.lang.IllegalStateException: suppressedLevel1
        at org.jboss.logmanager.formatters.PatternFormatterTests.extendedThrowable(PatternFormatterTests.java:197)
        ... 29 more
        Suppressed: java.lang.IllegalThreadStateException: suppressedLevel2
            at org.jboss.logmanager.formatters.PatternFormatterTests.extendedThrowable(PatternFormatterTests.java:199)
            ... 29 more
            Suppressed: java.lang.RuntimeException: suppressedLevel3
                at org.jboss.logmanager.formatters.PatternFormatterTests.extendedThrowable(PatternFormatterTests.java:248)
                ... 29 more
            Suppressed: java.lang.RuntimeException: suppressedLevel1a
                at org.jboss.logmanager.formatters.PatternFormatterTests.extendedThrowable(PatternFormatterTests.java:198)
                ... 29 more
    [CIRCULAR REFERENCE:java.lang.RuntimeException: suppressedLevel1a]
Caused by: java.lang.IllegalArgumentException: cause
    at org.jboss.logmanager.formatters.PatternFormatterTests.extendedThrowable(PatternFormatterTests.java:195)
    ... 29 more
    [CIRCULAR REFERENCE:java.lang.IllegalStateException: suppressedLevel1]
```