### PR TITLE
LOGMGR-125 1.5

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandler.java
@@ -20,6 +20,12 @@
 package org.jboss.logmanager.handlers;
 
 import org.jboss.logmanager.ExtLogRecord;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Calendar;
@@ -177,10 +183,11 @@ public class PeriodicRotatingFileHandler extends FileHandler {
             // first, close the original file (some OSes won't let you move/rename a file that is open)
             setFile(null);
             // next, rotate it
-            file.renameTo(new File(file.getAbsolutePath() + nextSuffix));
+            final Path target = Paths.get(file.getAbsolutePath() + nextSuffix);
+            Files.move(file.toPath(), target, StandardCopyOption.REPLACE_EXISTING);
             // start new file
             setFile(file);
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             reportError("Unable to rotate log file", e, ErrorManager.OPEN_FAILURE);
         }
     }

--- a/src/main/java/org/jboss/logmanager/handlers/PeriodicSizeRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/PeriodicSizeRotatingFileHandler.java
@@ -21,7 +21,12 @@ package org.jboss.logmanager.handlers;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.logging.ErrorManager;
 
 import org.jboss.logmanager.ExtLogRecord;
@@ -140,12 +145,21 @@ public class PeriodicSizeRotatingFileHandler extends PeriodicRotatingFileHandler
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws RuntimeException if there is an attempt to rotate file and the rotation fails
+     */
     @Override
     public void setFile(final File file) throws FileNotFoundException {
         synchronized (outputLock) {
             // Check for a rotate
             if (rotateOnBoot && maxBackupIndex > 0 && file != null && file.exists() && file.length() > 0L) {
-                rotate(file);
+                try {
+                    rotate(file);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
             super.setFile(file);
             if (outputStream != null)
@@ -218,19 +232,23 @@ public class PeriodicSizeRotatingFileHandler extends PeriodicRotatingFileHandler
                 rotate(file);
                 // start with new file.
                 setFile(file);
-            } catch (FileNotFoundException e) {
+            } catch (IOException e) {
                 reportError("Unable to rotate log file", e, ErrorManager.OPEN_FAILURE);
             }
         }
     }
 
-    private void rotate(final File file) {
-        final File fileWithSuffix = new File(file.getAbsolutePath() + getNextSuffix());
-        // rotate.  First, drop the max file (if any), then move each file to the next higher slot.
-        new File(fileWithSuffix.getAbsolutePath() + "." + maxBackupIndex).delete();
+    private void rotate(final File file) throws IOException {
+        final Path fileWithSuffix = Paths.get(file.getAbsolutePath() + getNextSuffix());
+        Files.deleteIfExists(Paths.get(fileWithSuffix + "." + maxBackupIndex));
         for (int i = maxBackupIndex - 1; i >= 1; i--) {
-            new File(fileWithSuffix.getAbsolutePath() + "." + i).renameTo(new File(fileWithSuffix.getAbsolutePath() + "." + (i + 1)));
+            final Path src = Paths.get(fileWithSuffix + "." + i);
+            if (Files.notExists(src)) {
+                break;
+            }
+            final Path target = Paths.get(fileWithSuffix + "." + (i + 1));
+            Files.move(src, target, StandardCopyOption.REPLACE_EXISTING);
         }
-        file.renameTo(new File(fileWithSuffix.getAbsolutePath() + ".1"));
+        Files.move(file.toPath(), Paths.get(fileWithSuffix + ".1"), StandardCopyOption.REPLACE_EXISTING);
     }
 }

--- a/src/main/java/org/jboss/logmanager/handlers/PeriodicSizeRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/PeriodicSizeRotatingFileHandler.java
@@ -243,11 +243,10 @@ public class PeriodicSizeRotatingFileHandler extends PeriodicRotatingFileHandler
         Files.deleteIfExists(Paths.get(fileWithSuffix + "." + maxBackupIndex));
         for (int i = maxBackupIndex - 1; i >= 1; i--) {
             final Path src = Paths.get(fileWithSuffix + "." + i);
-            if (Files.notExists(src)) {
-                break;
+            if (Files.exists(src)) {
+                final Path target = Paths.get(fileWithSuffix + "." + (i + 1));
+                Files.move(src, target, StandardCopyOption.REPLACE_EXISTING);
             }
-            final Path target = Paths.get(fileWithSuffix + "." + (i + 1));
-            Files.move(src, target, StandardCopyOption.REPLACE_EXISTING);
         }
         Files.move(file.toPath(), Paths.get(fileWithSuffix + ".1"), StandardCopyOption.REPLACE_EXISTING);
     }

--- a/src/main/java/org/jboss/logmanager/handlers/SizeRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/SizeRotatingFileHandler.java
@@ -260,11 +260,10 @@ public class SizeRotatingFileHandler extends FileHandler {
             Files.deleteIfExists(Paths.get(file.getAbsolutePath() + "." + maxBackupIndex));
             for (int i = maxBackupIndex - 1; i >= 1; i--) {
                 final Path src = Paths.get(file.getAbsolutePath() + "." + i);
-                if (Files.notExists(src)) {
-                    break;
+                if (Files.exists(src)) {
+                    final Path target = Paths.get(file.getAbsolutePath() + "." + (i + 1));
+                    Files.move(src, target, StandardCopyOption.REPLACE_EXISTING);
                 }
-                final Path target = Paths.get(file.getAbsolutePath() + "." + (i + 1));
-                Files.move(src, target, StandardCopyOption.REPLACE_EXISTING);
             }
             Files.move(file.toPath(), Paths.get(file.getAbsolutePath() + ".1"), StandardCopyOption.REPLACE_EXISTING);
         } else {
@@ -277,11 +276,10 @@ public class SizeRotatingFileHandler extends FileHandler {
             Files.deleteIfExists(Paths.get(newBaseFilename + "." + maxBackupIndex));
             for (int i = maxBackupIndex - 1; i >= 1; i--) {
                 final Path src = Paths.get(newBaseFilename + "." + i);
-                if (Files.notExists(src)) {
-                    break;
+                if (Files.exists(src)) {
+                    final Path target = Paths.get(newBaseFilename + "." + (i + 1));
+                    Files.move(src, target, StandardCopyOption.REPLACE_EXISTING);
                 }
-                final Path target = Paths.get(newBaseFilename + "." + (i + 1));
-                Files.move(src, target, StandardCopyOption.REPLACE_EXISTING);
             }
             // Rename the current file
             Files.move(file.toPath(), Paths.get(newBaseFilename + ".1"), StandardCopyOption.REPLACE_EXISTING);

--- a/src/main/java/org/jboss/logmanager/handlers/SizeRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/SizeRotatingFileHandler.java
@@ -19,11 +19,16 @@
 
 package org.jboss.logmanager.handlers;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import org.jboss.logmanager.ExtLogRecord;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.logging.ErrorManager;
@@ -131,12 +136,20 @@ public class SizeRotatingFileHandler extends FileHandler {
         }
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * @throws RuntimeException if there is an attempt to rotate file and the rotation fails
+     */
     public void setFile(final File file) throws FileNotFoundException {
         synchronized (outputLock) {
             // Check for a rotate
             if (rotateOnBoot && maxBackupIndex > 0 && file != null && file.exists() && file.length() > 0L) {
-                rotate(file);
+                try {
+                    rotate(file);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
             super.setFile(file);
             if (outputStream != null)
@@ -235,32 +248,43 @@ public class SizeRotatingFileHandler extends FileHandler {
                 rotate(file);
                 // start with new file.
                 setFile(file);
-            } catch (FileNotFoundException e) {
+            } catch (IOException e) {
                 reportError("Unable to rotate log file", e, ErrorManager.OPEN_FAILURE);
             }
         }
     }
 
-    private void rotate(final File file) {
+    private void rotate(final File file) throws IOException {
         if (suffix == null) {
             // rotate.  First, drop the max file (if any), then move each file to the next higher slot.
-            new File(file.getAbsolutePath() + "." + maxBackupIndex).delete();
+            Files.deleteIfExists(Paths.get(file.getAbsolutePath() + "." + maxBackupIndex));
             for (int i = maxBackupIndex - 1; i >= 1; i--) {
-                new File(file.getAbsolutePath() + "." + i).renameTo(new File(file.getAbsolutePath() + "." + (i + 1)));
+                final Path src = Paths.get(file.getAbsolutePath() + "." + i);
+                if (Files.notExists(src)) {
+                    break;
+                }
+                final Path target = Paths.get(file.getAbsolutePath() + "." + (i + 1));
+                Files.move(src, target, StandardCopyOption.REPLACE_EXISTING);
             }
-            file.renameTo(new File(file.getAbsolutePath() + ".1"));
+            Files.move(file.toPath(), Paths.get(file.getAbsolutePath() + ".1"), StandardCopyOption.REPLACE_EXISTING);
         } else {
             // This is not efficient, but performance risks were noted on the setSuffix() method
             final String suffix = new SimpleDateFormat(this.suffix).format(new Date());
             // Create the file name
             final String newBaseFilename = file.getAbsolutePath() + suffix;
 
-            // Rename any incremental files found
+            // rotate.  First, drop the max file (if any), then move each file to the next higher slot.
+            Files.deleteIfExists(Paths.get(newBaseFilename + "." + maxBackupIndex));
             for (int i = maxBackupIndex - 1; i >= 1; i--) {
-                new File(newBaseFilename + "." + i).renameTo(new File(newBaseFilename + "." + (i + 1)));
+                final Path src = Paths.get(newBaseFilename + "." + i);
+                if (Files.notExists(src)) {
+                    break;
+                }
+                final Path target = Paths.get(newBaseFilename + "." + (i + 1));
+                Files.move(src, target, StandardCopyOption.REPLACE_EXISTING);
             }
             // Rename the current file
-            file.renameTo(new File(newBaseFilename + ".1"));
+            Files.move(file.toPath(), Paths.get(newBaseFilename + ".1"), StandardCopyOption.REPLACE_EXISTING);
         }
     }
 }

--- a/src/test/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandlerTests.java
+++ b/src/test/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandlerTests.java
@@ -1,0 +1,125 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager.handlers;
+
+import java.io.BufferedWriter;
+import java.io.FileNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.List;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.Level;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
+    private final static String FILENAME = "periodic-rotating-file-handler.log";
+
+    private final Path logFile = BASE_LOG_DIR.toPath().resolve(FILENAME);
+
+    private final SimpleDateFormat rotateFormatter = new SimpleDateFormat(".dd");
+    private PeriodicRotatingFileHandler handler;
+
+    @Before
+    public void createHandler() throws FileNotFoundException {
+        // Create the handler
+        handler = new PeriodicRotatingFileHandler(logFile.toFile(), rotateFormatter.toPattern(), false);
+        handler.setFormatter(FORMATTER);
+    }
+
+    @After
+    public void closeHandler() {
+        handler.close();
+        handler = null;
+    }
+
+    @Test
+    public void testRotate() throws Exception {
+        final Path rotatedFile = BASE_LOG_DIR.toPath().resolve(FILENAME + rotateFormatter.format(createCalendar().getTime()));
+        testRotate(createCalendar(), rotatedFile);
+    }
+
+    @Test
+    public void testOverwriteRotate() throws Exception {
+        final Path rotatedFile = BASE_LOG_DIR.toPath().resolve(FILENAME + rotateFormatter.format(createCalendar().getTime()));
+
+        // Create the rotated file to ensure at some point it gets overwritten
+        Files.deleteIfExists(rotatedFile);
+        try (final BufferedWriter writer = Files.newBufferedWriter(rotatedFile, StandardCharsets.UTF_8)) {
+            writer.write("Adding data to the file");
+        }
+        testRotate(createCalendar(), rotatedFile);
+    }
+
+
+    private void testRotate(final Calendar cal, final Path rotatedFile) throws Exception {
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        final int currentDay = cal.get(Calendar.DAY_OF_MONTH);
+        final int nextDay = currentDay + 1;
+
+        final String currentDate = sdf.format(cal.getTime());
+
+        // Create a log message to be logged
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        handler.publish(record);
+
+        Assert.assertTrue("File '" + logFile + "' does not exist", Files.exists(logFile));
+
+        // Read the contents of the log file and ensure there's only one line and that like
+        List<String> lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+        Assert.assertEquals("More than 1 line found", 1, lines.size());
+        Assert.assertTrue("Expected the line to contain the date: " + currentDate, lines.get(0).contains(currentDate));
+
+        // Create a new record, increment the day by one and validate
+        cal.set(Calendar.DAY_OF_MONTH, nextDay);
+        final String nextDate = sdf.format(cal.getTime());
+        record = createLogRecord(Level.INFO, "Date: %s", nextDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+
+        // Read the contents of the log file and ensure there's only one line and that like
+        lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+        Assert.assertEquals("More than 1 line found", 1, lines.size());
+        Assert.assertTrue("Expected the line to contain the date: " + nextDate, lines.get(0).contains(nextDate));
+
+        // The file should have been rotated as well
+        Assert.assertTrue("The rotated file '" + rotatedFile.toString() + "' does not exist", Files.exists(rotatedFile));
+        lines = Files.readAllLines(rotatedFile, StandardCharsets.UTF_8);
+        Assert.assertEquals("More than 1 line found", 1, lines.size());
+        Assert.assertTrue("Expected the line to contain the date: " + currentDate, lines.get(0).contains(currentDate));
+    }
+
+    private Calendar createCalendar() {
+        final Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.YEAR, 2015);
+        calendar.set(Calendar.MONTH, Calendar.OCTOBER);
+        calendar.set(Calendar.DAY_OF_MONTH, 21);
+        return calendar;
+    }
+}

--- a/src/test/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandlerTests.java
+++ b/src/test/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandlerTests.java
@@ -61,20 +61,25 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
 
     @Test
     public void testRotate() throws Exception {
-        final Path rotatedFile = BASE_LOG_DIR.toPath().resolve(FILENAME + rotateFormatter.format(createCalendar().getTime()));
-        testRotate(createCalendar(), rotatedFile);
+        final Calendar cal = Calendar.getInstance();
+        final Path rotatedFile = BASE_LOG_DIR.toPath().resolve(FILENAME + rotateFormatter.format(cal.getTime()));
+        testRotate(cal, rotatedFile);
     }
 
     @Test
     public void testOverwriteRotate() throws Exception {
-        final Path rotatedFile = BASE_LOG_DIR.toPath().resolve(FILENAME + rotateFormatter.format(createCalendar().getTime()));
+        final Calendar cal = Calendar.getInstance();
+        final Path rotatedFile = BASE_LOG_DIR.toPath().resolve(FILENAME + rotateFormatter.format(cal.getTime()));
 
         // Create the rotated file to ensure at some point it gets overwritten
         Files.deleteIfExists(rotatedFile);
-        try (final BufferedWriter writer = Files.newBufferedWriter(rotatedFile, StandardCharsets.UTF_8)) {
+        final BufferedWriter writer = Files.newBufferedWriter(rotatedFile, StandardCharsets.UTF_8);
+        try {
             writer.write("Adding data to the file");
+        } finally {
+            writer.close();
         }
-        testRotate(createCalendar(), rotatedFile);
+        testRotate(cal, rotatedFile);
     }
 
 
@@ -97,7 +102,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
         Assert.assertTrue("Expected the line to contain the date: " + currentDate, lines.get(0).contains(currentDate));
 
         // Create a new record, increment the day by one and validate
-        cal.set(Calendar.DAY_OF_MONTH, nextDay);
+        cal.add(Calendar.DAY_OF_MONTH, nextDay);
         final String nextDate = sdf.format(cal.getTime());
         record = createLogRecord(Level.INFO, "Date: %s", nextDate);
         record.setMillis(cal.getTimeInMillis());
@@ -105,6 +110,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
 
         // Read the contents of the log file and ensure there's only one line and that like
         lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+        System.out.println(lines);
         Assert.assertEquals("More than 1 line found", 1, lines.size());
         Assert.assertTrue("Expected the line to contain the date: " + nextDate, lines.get(0).contains(nextDate));
 
@@ -113,13 +119,5 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
         lines = Files.readAllLines(rotatedFile, StandardCharsets.UTF_8);
         Assert.assertEquals("More than 1 line found", 1, lines.size());
         Assert.assertTrue("Expected the line to contain the date: " + currentDate, lines.get(0).contains(currentDate));
-    }
-
-    private Calendar createCalendar() {
-        final Calendar calendar = Calendar.getInstance();
-        calendar.set(Calendar.YEAR, 2015);
-        calendar.set(Calendar.MONTH, Calendar.OCTOBER);
-        calendar.set(Calendar.DAY_OF_MONTH, 21);
-        return calendar;
     }
 }


### PR DESCRIPTION
LOGMGR-125 backported to the 1.5 branch. The commit to fix the test is modified to not use try-with-resources since that doesn't work on Java 6.