### PR TITLE
[LOGMGR-125]: Log rotation fails on Windows if target already exists.

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/FileMove.java
+++ b/src/main/java/org/jboss/logmanager/handlers/FileMove.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.logmanager.handlers;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ *
+ * @author panos
+ */
+public class FileMove {
+
+    public static void move(File afile, File bfile) throws IOException {
+        InputStream inStream = null;
+        OutputStream outStream = null;
+
+        try {
+            inStream = new FileInputStream(afile);
+            outStream = new FileOutputStream(bfile);
+            byte[] buffer = new byte[1024];
+
+            int length;
+            //copy the file content in bytes 
+            while ((length = inStream.read(buffer)) > 0) {
+                outStream.write(buffer, 0, length);
+            }
+
+            //delete the original file
+            afile.delete();
+        } finally {
+            inStream.close();
+            outStream.close();
+        }
+    }
+}

--- a/src/main/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandler.java
@@ -20,6 +20,8 @@
 package org.jboss.logmanager.handlers;
 
 import org.jboss.logmanager.ExtLogRecord;
+
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Calendar;
@@ -177,10 +179,11 @@ public class PeriodicRotatingFileHandler extends FileHandler {
             // first, close the original file (some OSes won't let you move/rename a file that is open)
             setFile(null);
             // next, rotate it
-            file.renameTo(new File(file.getAbsolutePath() + nextSuffix));
+            final File target = new File(file.getAbsolutePath() + nextSuffix);
+            FileMove.move(file, target);
             // start new file
             setFile(file);
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             reportError("Unable to rotate log file", e, ErrorManager.OPEN_FAILURE);
         }
     }

--- a/src/main/java/org/jboss/logmanager/handlers/SizeRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/SizeRotatingFileHandler.java
@@ -19,11 +19,11 @@
 
 package org.jboss.logmanager.handlers;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import org.jboss.logmanager.ExtLogRecord;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.logging.ErrorManager;
@@ -131,12 +131,20 @@ public class SizeRotatingFileHandler extends FileHandler {
         }
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * @throws RuntimeException if there is an attempt to rotate file and the rotation fails
+     */
     public void setFile(final File file) throws FileNotFoundException {
         synchronized (outputLock) {
             // Check for a rotate
             if (rotateOnBoot && maxBackupIndex > 0 && file != null && file.exists() && file.length() > 0L) {
-                rotate(file);
+                try {
+                    rotate(file);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
             super.setFile(file);
             if (outputStream != null)
@@ -235,32 +243,43 @@ public class SizeRotatingFileHandler extends FileHandler {
                 rotate(file);
                 // start with new file.
                 setFile(file);
-            } catch (FileNotFoundException e) {
+            } catch (IOException e) {
                 reportError("Unable to rotate log file", e, ErrorManager.OPEN_FAILURE);
             }
         }
     }
 
-    private void rotate(final File file) {
+    private void rotate(final File file) throws IOException {
         if (suffix == null) {
             // rotate.  First, drop the max file (if any), then move each file to the next higher slot.
-            new File(file.getAbsolutePath() + "." + maxBackupIndex).delete();
+            String filePath = file.getAbsolutePath();
+            new File(filePath + "." + maxBackupIndex).delete();
             for (int i = maxBackupIndex - 1; i >= 1; i--) {
-                new File(file.getAbsolutePath() + "." + i).renameTo(new File(file.getAbsolutePath() + "." + (i + 1)));
+                final File src = new File(filePath + "." + i);
+                if (src.exists()) {
+                    final File target = new File(filePath + "." + (i + 1));
+                    FileMove.move(src, target);
+                }
             }
-            file.renameTo(new File(file.getAbsolutePath() + ".1"));
+            FileMove.move(file, new File(filePath + ".1"));
         } else {
             // This is not efficient, but performance risks were noted on the setSuffix() method
             final String suffix = new SimpleDateFormat(this.suffix).format(new Date());
             // Create the file name
             final String newBaseFilename = file.getAbsolutePath() + suffix;
 
-            // Rename any incremental files found
+            // rotate.  First, drop the max file (if any), then move each file to the next higher slot.
+            File newBaseFile = new File(newBaseFilename + "." + maxBackupIndex);
+            if (newBaseFile.exists())
+                newBaseFile.delete();
             for (int i = maxBackupIndex - 1; i >= 1; i--) {
-                new File(newBaseFilename + "." + i).renameTo(new File(newBaseFilename + "." + (i + 1)));
+                final File src = new File(newBaseFilename + "." + i);
+                if (src.exists()) {
+                    final File target = new File(newBaseFilename + "." + (i + 1));
+                    FileMove.move(src, target);
+                }
             }
-            // Rename the current file
-            file.renameTo(new File(newBaseFilename + ".1"));
+            FileMove.move(file, new File(newBaseFilename + ".1"));
         }
     }
 }

--- a/src/test/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandlerTests.java
+++ b/src/test/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandlerTests.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.logmanager.handlers;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.Level;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
+
+    private final static String FILENAME = "periodic-rotating-file-handler.log";
+
+    private final String logFile = BASE_LOG_DIR.toString() + File.separator + FILENAME;
+
+    private final SimpleDateFormat rotateFormatter = new SimpleDateFormat(".yyyy-MM-dd");
+    private PeriodicRotatingFileHandler handler;
+
+    @Before
+    public void createHandler() throws FileNotFoundException {
+        // Create the handler
+        File logFile = new File(this.logFile);
+        handler = new PeriodicRotatingFileHandler(logFile, rotateFormatter.toPattern(), false);
+        handler.setFormatter(FORMATTER);
+    }
+
+    @After
+    public void closeHandler() {
+        handler.close();
+        handler = null;
+    }
+
+    @Test
+    public void testRotate() throws Exception {
+        final Calendar cal = Calendar.getInstance();
+        final String rotatedPath = BASE_LOG_DIR.toString() + File.separator + FILENAME + rotateFormatter.format(cal.getTime());
+        File rotatedFile = new File(rotatedPath);
+        testRotate(cal, rotatedFile);
+    }
+
+    @Test
+    public void testOverwriteRotate() throws Exception {
+        final Calendar cal = Calendar.getInstance();
+        final String rotatedPath = BASE_LOG_DIR.toString() + File.separator + FILENAME + rotateFormatter.format(cal.getTime());
+
+        // Create the rotated file to ensure at some point it gets overwritten
+        File rotatedFile = new File(rotatedPath);
+
+        if (rotatedFile.exists()) {
+            rotatedFile.delete();
+        }
+
+        FileWriter fwriter = null;
+        BufferedWriter writer = null;
+        try {
+            fwriter = new FileWriter(rotatedFile.getAbsolutePath());
+            writer = new BufferedWriter(fwriter);
+            writer.write("Adding data to the file");
+        } finally {
+            writer.close();
+        }
+        testRotate(cal, rotatedFile);
+    }
+
+    private void testRotate(final Calendar cal, final File rotatedFile) throws Exception {
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        File logFile = new File(this.logFile);
+
+        final String currentDate = sdf.format(cal.getTime());
+
+        // Create a log message to be logged
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        handler.publish(record);
+
+        Assert.assertTrue("File '" + logFile.getName() + "' does not exist", logFile.exists());
+
+        // Read the contents of the log file and ensure there's only one line and that like
+        List<String> lines = readAllLines(logFile);
+        Assert.assertEquals("More than 1 line found", 1, lines.size());
+        Assert.assertTrue("Expected the line to contain the date: " + currentDate, lines.get(0).contains(currentDate));
+
+        // Create a new record, increment the day by one and validate
+        cal.add(Calendar.DAY_OF_MONTH, 1);
+        final String nextDate = sdf.format(cal.getTime());
+        record = createLogRecord(Level.INFO, "Date: %s", nextDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+
+        // Read the contents of the log file and ensure there's only one line and that like
+        lines = readAllLines(logFile);
+        Assert.assertEquals("More than 1 line found", 1, lines.size());
+        Assert.assertTrue("Expected the line to contain the date: " + nextDate, lines.get(0).contains(nextDate));
+
+        // The file should have been rotated as well
+        Assert.assertTrue("The rotated file '" + rotatedFile.getName() + "' does not exist", rotatedFile.exists());
+        lines = readAllLines(rotatedFile);
+        Assert.assertEquals("More than 1 line found", 1, lines.size());
+        Assert.assertTrue("Expected the line to contain the date: " + currentDate, lines.get(0).contains(currentDate));
+    }
+
+    private List<String> readAllLines(File f) throws FileNotFoundException, IOException {
+        List<String> list = new ArrayList();
+
+        BufferedReader br = new BufferedReader(new FileReader(f));
+        String line;
+        while ((line = br.readLine()) != null) {
+            list.add(line);
+        }
+
+        return list;
+    }
+}


### PR DESCRIPTION
[JBEAP-1719] : https://issues.jboss.org/browse/JBEAP-1719
[LOGMGR-125] : https://issues.jboss.org/browse/LOGMGR-125
[Upstream] : https://github.com/jboss-logging/jboss-logmanager/pull/88