### PR TITLE
Minor fixes for the FileMove LOGMGR-125 change

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/FileMove.java
+++ b/src/main/java/org/jboss/logmanager/handlers/FileMove.java
@@ -18,6 +18,7 @@
  */
 package org.jboss.logmanager.handlers;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -28,29 +29,55 @@ import java.io.OutputStream;
 /**
  *
  * @author panos
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class FileMove {
+class FileMove {
 
-    public static void move(File afile, File bfile) throws IOException {
-        InputStream inStream = null;
-        OutputStream outStream = null;
+    /**
+     * Moves the source file to the target file. The target file is first deleted if it exists, then a
+     * {@linkplain File#renameTo(File) rename} is attempted. If the rename fails the source file is copied byte for byte
+     * to the target finally deleting the source file in the end.
+     *
+     * @param src    the source file to copy
+     * @param target the target file
+     *
+     * @throws IOException if an error occurs moving the file
+     */
+    public static void move(final File src, final File target) throws IOException {
+        // If the target (bfile) exists, delete it first. In some cases this should allow the rename to succeed
+        if (target.exists()) {
+            target.delete();
+        }
+        // First attempt to rename the file, if that fails manually copy the file
+        if (!src.renameTo(target)) {
 
-        try {
-            inStream = new FileInputStream(afile);
-            outStream = new FileOutputStream(bfile);
-            byte[] buffer = new byte[1024];
+            InputStream inStream = null;
+            OutputStream outStream = null;
 
-            int length;
-            //copy the file content in bytes 
-            while ((length = inStream.read(buffer)) > 0) {
-                outStream.write(buffer, 0, length);
+            try {
+                inStream = new FileInputStream(src);
+                outStream = new FileOutputStream(target);
+                byte[] buffer = new byte[1024];
+
+                int length;
+                //copy the file content in bytes
+                while ((length = inStream.read(buffer)) > 0) {
+                    outStream.write(buffer, 0, length);
+                }
+
+                //delete the original file
+                src.delete();
+            } finally {
+                safeClose(inStream);
+                safeClose(outStream);
             }
+        }
+    }
 
-            //delete the original file
-            afile.delete();
-        } finally {
-            inStream.close();
-            outStream.close();
+    private static void safeClose(final Closeable closeable) {
+        if (closeable != null) try {
+            closeable.close();
+        } catch (Exception ignore) {
         }
     }
 }

--- a/src/test/java/org/jboss/logmanager/handlers/AbstractHandlerTest.java
+++ b/src/test/java/org/jboss/logmanager/handlers/AbstractHandlerTest.java
@@ -19,6 +19,7 @@
 
 package org.jboss.logmanager.handlers;
 
+import java.io.Closeable;
 import java.io.File;
 
 import org.jboss.logmanager.ExtHandler;
@@ -85,6 +86,13 @@ public class AbstractHandlerTest {
             }
         }
         return true;
+    }
+
+    static void safeClose(final Closeable closeable) {
+        if (closeable != null) try {
+            closeable.close();
+        } catch (Exception ignore) {
+        }
     }
 
     protected static void configureHandlerDefaults(final ExtHandler handler) {

--- a/src/test/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandlerTests.java
+++ b/src/test/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandlerTests.java
@@ -49,7 +49,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
     @Before
     public void createHandler() throws FileNotFoundException {
         // Create the handler
-        File logFile = new File(this.logFile);
+        final File logFile = new File(this.logFile);
         handler = new PeriodicRotatingFileHandler(logFile, rotateFormatter.toPattern(), false);
         handler.setFormatter(FORMATTER);
     }
@@ -64,7 +64,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
     public void testRotate() throws Exception {
         final Calendar cal = Calendar.getInstance();
         final String rotatedPath = BASE_LOG_DIR.toString() + File.separator + FILENAME + rotateFormatter.format(cal.getTime());
-        File rotatedFile = new File(rotatedPath);
+        final File rotatedFile = new File(rotatedPath);
         testRotate(cal, rotatedFile);
     }
 
@@ -74,27 +74,25 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
         final String rotatedPath = BASE_LOG_DIR.toString() + File.separator + FILENAME + rotateFormatter.format(cal.getTime());
 
         // Create the rotated file to ensure at some point it gets overwritten
-        File rotatedFile = new File(rotatedPath);
+        final File rotatedFile = new File(rotatedPath);
 
         if (rotatedFile.exists()) {
             rotatedFile.delete();
         }
 
-        FileWriter fwriter = null;
         BufferedWriter writer = null;
         try {
-            fwriter = new FileWriter(rotatedFile.getAbsolutePath());
-            writer = new BufferedWriter(fwriter);
+            writer = new BufferedWriter(new FileWriter(rotatedFile.getAbsoluteFile()));
             writer.write("Adding data to the file");
         } finally {
-            writer.close();
+            safeClose(writer);
         }
         testRotate(cal, rotatedFile);
     }
 
     private void testRotate(final Calendar cal, final File rotatedFile) throws Exception {
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        File logFile = new File(this.logFile);
+        final File logFile = new File(this.logFile);
 
         final String currentDate = sdf.format(cal.getTime());
 
@@ -128,13 +126,18 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
         Assert.assertTrue("Expected the line to contain the date: " + currentDate, lines.get(0).contains(currentDate));
     }
 
-    private List<String> readAllLines(File f) throws FileNotFoundException, IOException {
-        List<String> list = new ArrayList();
+    private List<String> readAllLines(final File f) throws IOException {
+        final List<String> list = new ArrayList<String>();
 
-        BufferedReader br = new BufferedReader(new FileReader(f));
-        String line;
-        while ((line = br.readLine()) != null) {
-            list.add(line);
+        BufferedReader br = null;
+        try {
+            br = new BufferedReader(new FileReader(f));
+            String line;
+            while ((line = br.readLine()) != null) {
+                list.add(line);
+            }
+        } finally {
+            safeClose(br);
         }
 
         return list;


### PR DESCRIPTION
Made the `FileMove` package private and attempted a `File.renameTo()` before manually copying the file.

The second fix is to fix issues with the tests on Windows. Any open files need to ensure to be closed otherwise Windows cannot delete them.