### PR TITLE
BZ-1350757  StringIndexOutOfBoundsException throw while formatting log

### DIFF
--- a/src/main/java/org/jboss/logmanager/formatters/Formatters.java
+++ b/src/main/java/org/jboss/logmanager/formatters/Formatters.java
@@ -209,7 +209,7 @@ public final class Formatters {
                 final int overflow = writtenLen - maximumWidth;
                 if (overflow > 0) {
                     if (truncateBeginning) {
-                        builder.delete(oldLen, overflow + 1);
+                        builder.delete(oldLen, overflow + oldLen);
                     }
                     builder.setLength(newLen - overflow);
                 } else {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1350757

backport of what is already fixed in master: https://issues.jboss.org/browse/LOGMGR-141