### PR TITLE
[LOGMGR-177] Introduce an optional way to bootstrap logging. If enabl…

### DIFF
--- a/src/main/java/org/jboss/logmanager/Bootstrap.java
+++ b/src/main/java/org/jboss/logmanager/Bootstrap.java
@@ -1,0 +1,232 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.logging.Filter;
+import java.util.logging.Handler;
+
+import org.jboss.logmanager.handlers.FileHandler;
+
+/**
+ * A bootstrap helper that queues messages until the {@link #complete()} method is invoked.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class Bootstrap {
+
+    private final LoggerNode loggerNode;
+    private final Supplier<? extends Handler> handlerSupplier;
+    private final BootstrappedLogRecordPublisher publisher;
+    private final LogRecordPublisher handoffPublisher;
+    private final boolean isCalculateCaller;
+    private volatile boolean complete;
+    private volatile BootstrapLogTask bootstrapLogTask;
+
+    /**
+     * Creates a new bootstrap.
+     *
+     * @param loggerNode    the logger node to bootstrap
+     * @param configuration the configuration
+     */
+    Bootstrap(final LoggerNode loggerNode, final BootstrapConfiguration configuration) {
+        this.loggerNode = loggerNode;
+        this.handlerSupplier = configuration.getHandler();
+        handoffPublisher = LogRecordPublisher.DEFAULT;
+        if (configuration.isBootstrapEnabled()) {
+            publisher = new BootstrappedLogRecordPublisher(configuration.getQueueSize());
+            loggerNode.setLevel(configuration.getLevel());
+            bootstrapLogTask = registerShutdownHook();
+            complete = false;
+        } else {
+            publisher = null;
+            complete = true;
+        }
+        isCalculateCaller = configuration.isCalculateCaller();
+    }
+
+    /**
+     * Returns the log publisher currently being used.
+     *
+     * @return the log publisher
+     */
+    LogRecordPublisher getPublisher() {
+        return complete || publisher == null ? handoffPublisher : publisher;
+    }
+
+    /**
+     * Completes the bootstrapping by pushing queued messages to the {@linkplain LogRecordPublisher#DEFAULT default}
+     * publisher then replaces the publisher on all child logger nodes.
+     */
+    void complete() {
+        if (!complete) {
+            unregisterShutdownHook();
+            synchronized (publisher) {
+                publisher.drain();
+                complete = true;
+            }
+        }
+    }
+
+    private BootstrapLogTask registerShutdownHook() {
+        final BootstrapLogTask task = new BootstrapLogTask();
+        if (System.getSecurityManager() == null) {
+            Runtime.getRuntime().addShutdownHook(task);
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    Runtime.getRuntime().addShutdownHook(task);
+                    return null;
+                }
+            });
+        }
+        return task;
+    }
+
+    private void unregisterShutdownHook() {
+        final BootstrapLogTask bootstrapLogTask = this.bootstrapLogTask;
+        this.bootstrapLogTask = null;
+        if (bootstrapLogTask != null) {
+            if (System.getSecurityManager() == null) {
+                Runtime.getRuntime().removeShutdownHook(bootstrapLogTask);
+            } else {
+                AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                    @Override
+                    public Void run() {
+                        Runtime.getRuntime().removeShutdownHook(bootstrapLogTask);
+                        return null;
+                    }
+                });
+            }
+        }
+    }
+
+    private class BootstrapLogTask extends Thread {
+        @Override
+        public void run() {
+            bootstrapLogTask = null;
+            final Handler handler = handlerSupplier.get();
+            try {
+                // Add a handler to bootstrapped logger node
+                loggerNode.addHandler(handler);
+                if (handler instanceof FileHandler) {
+                    StandardOutputStreams.printError("Logging configuration was never committed before the " +
+                            "JVM was terminated. Messages were logged to %s.%n", ((FileHandler) handler).getFile().getAbsolutePath());
+                } else {
+                    StandardOutputStreams.printError("Logging configuration was never committed before the " +
+                            "JVM was terminated. Messages will be logged to handler %s.%n", handler);
+                }
+                // Complete the current configuration by draining the queue and allowing the handoff publisher to be
+                // used for any further logged messages
+                complete();
+            } catch (Exception e) {
+                if (publisher != null) {
+                    StandardOutputStreams.printError(e, "Failed to configure logging shutdown handler, replaying errors to stderr.");
+                    Entry entry;
+                    while ((entry = publisher.logRecords.pollFirst()) != null) {
+                        StandardOutputStreams.printError(entry.record.getFormattedMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    private class BootstrappedLogRecordPublisher implements LogRecordPublisher {
+
+        private final Deque<Entry> logRecords;
+        private final int queueSize;
+        private final AtomicBoolean warnedOverflow;
+
+        private BootstrappedLogRecordPublisher(final int queueSize) {
+            logRecords = new ArrayDeque<>(queueSize);
+            this.queueSize = queueSize;
+            warnedOverflow = new AtomicBoolean(false);
+        }
+
+        @Override
+        public synchronized void publish(final LoggerNode loggerNode, final ExtLogRecord record) {
+            // If a log message was blocked from being published because we were draining the queue, we can just
+            // directly send it to the handoff publisher.
+            if (complete) {
+                handoffPublisher.publish(loggerNode, record);
+            } else {
+                final ExtLogRecord rec = ExtLogRecord.wrap(record);
+                // If the caller calculation is required we need to calculate it, otherwise we need to disable it
+                if (isCalculateCaller) {
+                    rec.copyAll();
+                } else {
+                    rec.disableCallerCalculation();
+                    rec.copyMdc();
+                    rec.getFormattedMessage();
+                }
+                // Validate we're not going to overflow
+                final int currentSize = logRecords.size();
+                if (currentSize == queueSize) {
+                    logRecords.pollFirst();
+                    if (warnedOverflow.compareAndSet(false, true)) {
+                        StandardOutputStreams.printError("Log records queued exceed the maximum size of %d. For each " +
+                                "new message the earliest message on the queue will be removed.", queueSize);
+                    }
+                }
+                logRecords.addLast(new Entry(loggerNode, record));
+            }
+        }
+
+        synchronized void drain() {
+            Entry entry;
+            while ((entry = logRecords.pollFirst()) != null) {
+                final LoggerNode loggerNode = entry.loggerNode;
+                final ExtLogRecord record = entry.record;
+                // Check the per thread log filter, this is generally done in the Logger itself, however we're
+                // processing directly with a LoggerNode and need to validate this.
+                Filter filter = null;
+                final int effectiveLevel = loggerNode.getEffectiveLevel();
+                if (!(LogManager.PER_THREAD_LOG_FILTER && (filter = LogManager.getThreadLocalLogFilter()) != null) &&
+                        (record.getLevel().intValue() < effectiveLevel || effectiveLevel == Logger.OFF_INT)) {
+                    continue;
+                }
+                if (LogManager.PER_THREAD_LOG_FILTER && filter != null && !filter.isLoggable(record)) {
+                    continue;
+                }
+                // The record must still be loggable if we're going to publish it
+                if (loggerNode.isLoggable(record)) {
+                    handoffPublisher.publish(loggerNode, record);
+                }
+            }
+        }
+
+    }
+
+    private static class Entry {
+        final LoggerNode loggerNode;
+        final ExtLogRecord record;
+
+        private Entry(final LoggerNode loggerNode, final ExtLogRecord record) {
+            this.loggerNode = loggerNode;
+            this.record = record;
+        }
+    }
+}

--- a/src/main/java/org/jboss/logmanager/BootstrapConfiguration.java
+++ b/src/main/java/org/jboss/logmanager/BootstrapConfiguration.java
@@ -1,0 +1,442 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.function.Supplier;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.handlers.ConsoleHandler;
+import org.jboss.logmanager.handlers.FileHandler;
+import org.wildfly.common.Assert;
+
+/**
+ * Allows a {@link LogContext} to accept messages while it's still being configured. Once the configuration is complete
+ * the messages will be sent back through the log process in the order in which they came arrived. This API allows some
+ * minimal configuration on how bootstrapping is handled.
+ * <p>
+ * Once bootstrapping is complete the {@link LogContext#configurationComplete()} must be invoked in order to trigger
+ * the queued messages to be processed.
+ * </p>
+ * <p>
+ * Bootstrapping is said to be enabled when this configuration is explicitly {@linkplain #create(boolean) created}
+ * with {@code true} or the {@code org.jboss.logmanager.bootstrap.enabled} is set to {@code true}.
+ * </p>
+ * <p>
+ * If enabled a {@linkplain Runtime#addShutdownHook(Thread) shutdown hook} is added which will log messages if the JVM
+ * exists before the {@linkplain LogContext#configurationComplete() configuration is complete}. By default the messages
+ * will be written to a {@link FileHandler}. This can be overridden by changing the
+ * {@code org.jboss.logmanager.bootstrap.log.type} to {@code console} which will then write messages to a
+ * {@link ConsoleHandler}. If configuring either results in an error messages will be written to {@link System#err}.
+ * </p>
+ * <p>
+ * If the {@code org.jboss.logmanager.bootstrap.log.type} system property is not {@code console} or not defined the
+ * {@code org.jboss.logmanager.bootstrap.log.file} system property can be used to override the file the messages will
+ * be written to. If left undefined the default file will be {@code ./bootstrap}.
+ * </p>
+ * <table border="1" cellpadding="4">
+ * <caption style="text-align: left; padding-bottom: 5px"><strong>Available Configuration Properties</strong></caption>
+ * <thead>
+ * <tr>
+ * <th>System Property</th>
+ * <th>Description</th>
+ * <th>Allowed Values</th>
+ * <th>Default Value</th>
+ * </tr>
+ * </thead>
+ * <tbody>
+ * <tr>
+ * <td><code>org.jboss.logmanager.bootstrap.enabled</code></td>
+ * <td>Whether or not bootstrapping should be enabled.</td>
+ * <td><code>true</code> or <code>false</code></td>
+ * <td><code>false</code></td>
+ * </tr>
+ * <tr>
+ * <td><code>org.jboss.logmanager.bootstrap.level</code></td>
+ * <td>The level the root logger should be set to when bootstrapping is enabled. Note that the level used here
+ * will be set on the root logger. If another level is desired on the root logger it must be explicitly set.</td>
+ * <td>Any valid {@linkplain Level level}.</td>
+ * <td><code>INFO</code></td>
+ * </tr>
+ * <tr>
+ * <td><code>org.jboss.logmanager.bootstrap.log.type</code></td>
+ * <td>The type of the handler to use if the JVM exits before {@linkplain LogContext#configurationComplete()
+ * configuration is complete}.</td>
+ * <td><code>console</code> or <code>file</code></td>
+ * <td><code>file</code></td>
+ * </tr>
+ * <tr>
+ * <td><code>org.jboss.logmanager.bootstrap.log.file</code></td>
+ * <td>If the <code>org.jboss.logmanager.bootstrap.log.type</code> is set to <code>file</code> the path to the
+ * log file that should be used.</td>
+ * <td>Any valid path. If the parent directories do not exist they will be created.</td>
+ * <td><code>./bootstrap.log</code></td>
+ * </tr>
+ * <tr>
+ * <td><code>org.jboss.logmanager.bootstrap.queue-size</code></td>
+ * <td>The size of the queue for logged messages until the configuration.</td>
+ * <td>Any valid integer.</td>
+ * <td>10,000</td>
+ * <tr>
+ * <td><code>org.jboss.logmanager.bootstrap.calculate.caller</code></td>
+ * <td>Whether or not the caller should be calculated when the message is queued. Calculating the caller is an
+ * expensive operation. If it is known that the caller will not need to be calculated it is suggested to set
+ * this value to <code>false</code>.</td>
+ * <td><code>true</code> or <code>false</code></td>
+ * <td><code>true</code></td>
+ * </tr>
+ * </tbody>
+ * </table>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class BootstrapConfiguration {
+
+    private static final boolean BOOTSTRAP_ENABLED = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+        @Override
+        public Boolean run() {
+            final String value = System.getProperty("org.jboss.logmanager.bootstrap.enabled", "false");
+            return value.isEmpty() || Boolean.parseBoolean(value);
+        }
+    });
+
+    private static final Level BOOTSTRAP_LEVEL = AccessController.doPrivileged(new PrivilegedAction<Level>() {
+        @Override
+        public Level run() {
+            try {
+                return Level.parse(System.getProperty("org.jboss.logmanager.bootstrap.level", "INFO"));
+            } catch (Exception ignore) {
+            }
+            return Level.INFO;
+        }
+    });
+
+    private static final File BOOTSTRAP_FAILED_LOG_FILE = AccessController.doPrivileged(new PrivilegedAction<File>() {
+        @Override
+        public File run() {
+            try {
+                return new File(System.getProperty("org.jboss.logmanager.bootstrap.log.file", "./bootstrap.log"));
+            } catch (Exception ignore) {
+            }
+            return new File("./bootstrap.log");
+        }
+    });
+
+    private static final String BOOTSTRAP_FAILED_LOG_TYPE = AccessController.doPrivileged(new PrivilegedAction<String>() {
+        @Override
+        public String run() {
+            return System.getProperty("org.jboss.logmanager.bootstrap.log.type", "file");
+        }
+    });
+
+    private static final int BOOTSTRAP_QUEUE_SIZE = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
+        @Override
+        public Integer run() {
+            try {
+                return Integer.parseInt(System.getProperty("org.jboss.logmanager.bootstrap.queue-size", "10000"));
+            } catch (Exception ignore) {
+            }
+            return 10000;
+        }
+    });
+
+    private static final boolean CALCULATE_CALLER = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+        @Override
+        public Boolean run() {
+            final String value = System.getProperty("org.jboss.logmanager.bootstrap.calculate.caller", "true");
+            return value.isEmpty() || Boolean.parseBoolean(value);
+        }
+    });
+
+    private static final String PATTERN = "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n";
+
+    private final boolean enabled;
+
+    private Level level;
+    private Supplier<? extends Handler> handler;
+    private int queueSize;
+    private boolean isCalculateCaller;
+
+    private BootstrapConfiguration(final boolean enabled) {
+        this.enabled = enabled;
+        level = BOOTSTRAP_LEVEL;
+        queueSize = BOOTSTRAP_QUEUE_SIZE;
+        isCalculateCaller = CALCULATE_CALLER;
+    }
+
+    /**
+     * Creates a new bootstrap configuration that uses the {@code org.jboss.logmanager.bootstrap.enabled} system
+     * property to determine whether or not bootstrapping is enabled.
+     *
+     * @return a new bootstrap configuration
+     */
+    public static BootstrapConfiguration create() {
+        return new BootstrapConfiguration(BOOTSTRAP_ENABLED);
+    }
+
+    /**
+     * Creates a new bootstrap configuration.
+     *
+     * @param enabled {@code true} if the bootstrap configuration should be used or {@code false} if bootstraping
+     *                shouldn't be used
+     *
+     * @return a new bootstrap configuration
+     */
+    public static BootstrapConfiguration create(final boolean enabled) {
+        return new BootstrapConfiguration(enabled);
+    }
+
+    /**
+     * Checks whether or not bootstrapping has been enabled.
+     *
+     * @return {@code true} if bootstrapping has been enabled, otherwise {@code false}
+     */
+    public boolean isBootstrapEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Indicates whether or not the caller should be calculated when messages are queued. The default is {@code true}.
+     *
+     * @return {@code true} if the caller should be calculated, otherwise {@code false}
+     */
+    public boolean isCalculateCaller() {
+        return isCalculateCaller;
+    }
+
+    /**
+     * Sets whether or not the caller should be calculated before adding the log record to the queue.
+     * <p>
+     * Note that calculating the caller is an expensive operation. If it is known that the caller will not be required
+     * it is suggested to set this value to {@code false}.
+     * </p>
+     *
+     * @param calculateCaller {@code true} if the caller should be calculated, otherwise {@code false}
+     *
+     * @return this configuration
+     */
+    public BootstrapConfiguration setCalculateCaller(final boolean calculateCaller) {
+        isCalculateCaller = calculateCaller;
+        return this;
+    }
+
+    /**
+     * Returns a supplier for the handler to use for logging messages to if the JVM shuts down before
+     * {@link LogContext#configurationComplete()} is invoked.
+     *
+     * @return the supplier for the handler
+     */
+    public Supplier<? extends Handler> getHandler() {
+        if (this.handler == null) {
+            return getDefaultHandler();
+        }
+        return handler;
+    }
+
+    /**
+     * Sets the handler to use for logging messages to if the JVM shuts down before the
+     * {@link LogContext#configurationComplete()} is invoked.
+     *
+     * @param handler the handler to use
+     *
+     * @return this configuration
+     */
+    public BootstrapConfiguration setHandler(final Handler handler) {
+        Assert.checkNotNullParam("handler", handler);
+        return setHandler(new Supplier<Handler>() {
+            @Override
+            public Handler get() {
+                return handler;
+            }
+        });
+    }
+
+    /**
+     * Sets the handler to use for logging messages to if the JVM shuts down before the
+     * {@link LogContext#configurationComplete()} is invoked. Note the handler will lazily be initialized only if
+     * the shutdown hook is invoked.
+     *
+     * @param handler the handler to use
+     *
+     * @return this configuration
+     */
+    public BootstrapConfiguration setHandler(final Supplier<? extends Handler> handler) {
+        this.handler = Assert.checkNotNullParam("handler", handler);
+        return this;
+    }
+
+    /**
+     * A shortcut to supplying a {@link ConsoleHandler} which will be lazily loaded if the JVM shuts down before the
+     * {@link LogContext#configurationComplete()} is invoked.
+     *
+     * @return this configuration
+     */
+    public BootstrapConfiguration useConsoleHandler() {
+        return setHandler(new Supplier<Handler>() {
+            @Override
+            public Handler get() {
+                return new ConsoleHandler(new PatternFormatter(PATTERN));
+            }
+        });
+    }
+
+    /**
+     * A shortcut to supplying a {@link FileHandler} which will be lazily loaded if the JVM shuts down before the
+     * {@link LogContext#configurationComplete()} is invoked.
+     *
+     * @param path the path to the file to write messages to
+     *
+     * @return this configuration
+     */
+    public BootstrapConfiguration useFileHandler(final String path) {
+        return useFileHandler(new File(Assert.checkNotNullParam("path", path)));
+    }
+
+    /**
+     * A shortcut to supplying a {@link FileHandler} which will be lazily loaded if the JVM shuts down before the
+     * {@link LogContext#configurationComplete()} is invoked.
+     *
+     * @param path the path to the file to write messages to
+     *
+     * @return this configuration
+     */
+    public BootstrapConfiguration useFileHandler(final Path path) {
+        return useFileHandler(Assert.checkNotNullParam("path", path).toFile());
+    }
+
+    /**
+     * A shortcut to supplying a {@link FileHandler} which will be lazily loaded if the JVM shuts down before the
+     * {@link LogContext#configurationComplete()} is invoked.
+     *
+     * @param path the path to the file to write messages to
+     *
+     * @return this configuration
+     */
+    public BootstrapConfiguration useFileHandler(final File path) {
+        Assert.checkNotNullParam("path", path);
+        return setHandler(new Supplier<Handler>() {
+            @Override
+            public Handler get() {
+                try {
+                    return new FileHandler(new PatternFormatter(PATTERN), path, true);
+                } catch (FileNotFoundException e) {
+                    StandardOutputStreams.printError(e, "Could not create file handler, defaulting to a console " +
+                            "handler for message output");
+                    return new ConsoleHandler(new PatternFormatter(PATTERN));
+                }
+            }
+        });
+    }
+
+    /**
+     * Returns the level used for the bootstrapped messages.
+     *
+     * @return the level to use
+     */
+    public Level getLevel() {
+        return level == null ? BOOTSTRAP_LEVEL : level;
+    }
+
+    /**
+     * Allows the default level of {@link Level#INFO} to be overridden. This can also be controlled by the
+     * {@code org.jboss.logmanager.bootstrap.level} system property.
+     * <p>
+     * Note that the level used here will be set on the root logger. If a different root logging level is desired it
+     * must be explicitly set before the {@link LogContext#configurationComplete()} is invoked.
+     * </p>
+     *
+     * @param level the log level to use for bootstrapped messages or {@code null} to use the
+     *              {@code org.jboss.logmanager.bootstrap.level} system property.
+     *
+     * @return this configuration
+     */
+    public BootstrapConfiguration setLogLevel(final Level level) {
+        this.level = level;
+        return this;
+    }
+
+    /**
+     * Returns the maximum size of the queue for the bootstrapped log messages.
+     *
+     * @return the maximum queue size
+     */
+    public int getQueueSize() {
+        return queueSize;
+    }
+
+    /**
+     * Sets the maximum size of the queue for bootstrapped log messages. If the size is less than or equal to 0 the
+     * system property {@code org.jboss.logmanager.bootstrap.queue-size} will be used to determine the size. If the
+     * system property is not set 10,000 will be used.
+     *
+     * @param queueSize the queue size
+     *
+     * @return this configuration
+     */
+    public BootstrapConfiguration setQueueSize(final int queueSize) {
+        if (queueSize <= 0) {
+            this.queueSize = BOOTSTRAP_QUEUE_SIZE;
+        } else {
+            this.queueSize = queueSize;
+        }
+        return this;
+    }
+
+    /**
+     * If {@linkplain #isBootstrapEnabled() enabled} this will return a configured {@link Bootstrap}, otherwise
+     * {@code null} will be returned.
+     *
+     * @param loggerNode the logger node to associate with the bootstrap loggers
+     *
+     * @return a configured bootstrap or {@code null} if bootstrapping isn't enabled
+     */
+    Bootstrap build(final LoggerNode loggerNode) {
+        return new Bootstrap(loggerNode, this);
+    }
+
+    private Supplier<Handler> getDefaultHandler() {
+        if ("console".equalsIgnoreCase(BOOTSTRAP_FAILED_LOG_TYPE)) {
+            return new Supplier<Handler>() {
+                @Override
+                public Handler get() {
+                    return new ConsoleHandler(new PatternFormatter(PATTERN));
+                }
+            };
+        }
+        return new Supplier<Handler>() {
+            @Override
+            public Handler get() {
+                try {
+                    return new FileHandler(new PatternFormatter(PATTERN), BOOTSTRAP_FAILED_LOG_FILE, true);
+                } catch (FileNotFoundException e) {
+                    StandardOutputStreams.printError(e, PATTERN);
+                }
+                return new ConsoleHandler(ConsoleHandler.Target.SYSTEM_ERR, new PatternFormatter(PATTERN));
+            }
+        };
+    }
+}

--- a/src/main/java/org/jboss/logmanager/LogRecordPublisher.java
+++ b/src/main/java/org/jboss/logmanager/LogRecordPublisher.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.util.logging.Handler;
+
+/**
+ * Provides a way for a {@link LoggerNode} to write messages.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+interface LogRecordPublisher {
+
+    /**
+     * A default publisher which writes messages to a logger nodes handlers. This is done recursively if the
+     * logger nodes {@link LoggerNode#getUseParentHandlers()} is set to {@code true}.
+     */
+    LogRecordPublisher DEFAULT = new LogRecordPublisher() {
+        @Override
+        public void publish(final LoggerNode loggerNode, final ExtLogRecord record) {
+            for (Handler handler : loggerNode.getHandlers()) {
+                try {
+                    handler.publish(record);
+                } catch (VirtualMachineError e) {
+                    throw e;
+                } catch (Throwable t) {
+                    StandardOutputStreams.printError(t, "Failed to publish record to handler.");
+                }
+            }
+            if (loggerNode.getUseParentHandlers()) {
+                final LoggerNode parent = loggerNode.getParent();
+                // Use this publish method to avoid another push to a different publisher which may in turn rerun this
+                // publish method as well as avoid the isLoggable() check.
+                if (parent != null) publish(parent, record);
+            }
+        }
+    };
+
+    /**
+     * Publishes the record to the logger node.
+     *
+     * @param loggerNode the logger node to publish the record to
+     * @param record     the record to publish
+     */
+    void publish(LoggerNode loggerNode, ExtLogRecord record);
+}

--- a/src/main/java/org/jboss/logmanager/Logger.java
+++ b/src/main/java/org/jboss/logmanager/Logger.java
@@ -837,16 +837,6 @@ public final class Logger extends java.util.logging.Logger implements Serializab
             record.setResourceBundleName(bundleName);
             record.setResourceBundle(bundle);
         }
-        try {
-            if (!loggerNode.isLoggable(record)) {
-                return;
-            }
-        } catch (VirtualMachineError e) {
-            throw e;
-        } catch (Throwable t) {
-            // todo - error handler
-            // treat an errored filter as "pass" (I guess?)
-        }
         loggerNode.publish(record);
     }
 

--- a/src/main/java/org/jboss/logmanager/LoggerNode.java
+++ b/src/main/java/org/jboss/logmanager/LoggerNode.java
@@ -310,16 +310,17 @@ final class LoggerNode {
     }
 
     void publish(final ExtLogRecord record) {
-        for (Handler handler : handlers) try {
-            handler.publish(record);
+        boolean isLoggable = true;
+        try {
+            isLoggable = isLoggable(record);
         } catch (VirtualMachineError e) {
             throw e;
         } catch (Throwable t) {
             // todo - error handler
+            // treat an errored filter as "pass" (I guess?)
         }
-        if (useParentHandlers) {
-            final LoggerNode parent = this.parent;
-            if (parent != null) parent.publish(record);
+        if (isLoggable) {
+            context.getLogRecordPublisher().publish(this, record);
         }
     }
 

--- a/src/main/java/org/jboss/logmanager/config/LogContextConfigurationImpl.java
+++ b/src/main/java/org/jboss/logmanager/config/LogContextConfigurationImpl.java
@@ -297,6 +297,7 @@ final class LogContextConfigurationImpl implements LogContextConfiguration {
             prepare();
         }
         clear();
+        logContext.configurationComplete();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/jboss/logmanager/BootstrapLoggingTests.java
+++ b/src/test/java/org/jboss/logmanager/BootstrapLoggingTests.java
@@ -1,0 +1,333 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.common.cpu.ProcessorInfo;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class BootstrapLoggingTests {
+
+    private static final int ITERATIONS = Integer.parseInt(System.getProperty("org.jboss.bootstrap.test.iterations", "1000"));
+
+    @After
+    public void cleanup() {
+        TestHandler.MESSAGES.clear();
+    }
+
+    @Test
+    public void testBootstrapConfiguredConfigurationAPI() {
+        final LogContext logContext = LogContext.create(BootstrapConfiguration.create(true).useConsoleHandler());
+
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.info("Test message 1");
+        rootLogger.fine("Test message 2");
+
+        final Logger testLogger = logContext.getLogger(BootstrapLoggingTests.class.getName());
+        testLogger.warning("Test message 3");
+
+        final Logger randomLogger = logContext.getLogger(UUID.randomUUID().toString());
+        randomLogger.severe("Test message 4");
+
+        final LogContextConfiguration logContextConfiguration = LogContextConfiguration.Factory.create(logContext);
+        final HandlerConfiguration handlerConfiguration = logContextConfiguration.addHandlerConfiguration(
+                null, TestHandler.class.getName(), "test-handler");
+        logContextConfiguration.addLoggerConfiguration("").addHandlerName(handlerConfiguration.getName());
+        logContextConfiguration.commit();
+
+        rootLogger.info("Test message 5");
+        testLogger.severe("Test message 6");
+        randomLogger.finest("Test message 7");
+
+        // The default root logger message is INFO so FINE and FINEST should not be logged
+        Assert.assertEquals(5, TestHandler.MESSAGES.size());
+
+        // Test the messages actually logged
+        Assert.assertEquals("Test message 1", TestHandler.MESSAGES.get(0).getFormattedMessage());
+        Assert.assertEquals("Test message 3", TestHandler.MESSAGES.get(1).getFormattedMessage());
+        Assert.assertEquals("Test message 4", TestHandler.MESSAGES.get(2).getFormattedMessage());
+        Assert.assertEquals("Test message 5", TestHandler.MESSAGES.get(3).getFormattedMessage());
+        Assert.assertEquals("Test message 6", TestHandler.MESSAGES.get(4).getFormattedMessage());
+    }
+
+    @Test
+    public void testBootstrapConfigured() {
+        final LogContext logContext = LogContext.create(BootstrapConfiguration.create(true).useConsoleHandler().setLogLevel(Level.TRACE));
+
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.info("Test message 1");
+        rootLogger.fine("Test message 2");
+
+        final Logger testLogger = logContext.getLogger(BootstrapLoggingTests.class.getName());
+        testLogger.warning("Test message 3");
+
+        final Logger randomLogger = logContext.getLogger(UUID.randomUUID().toString());
+        randomLogger.severe("Test message 4");
+
+        final TestHandler handler = new TestHandler();
+        rootLogger.addHandler(handler);
+
+        // We're not resetting the root logger level so it should be left at TRACE
+        logContext.configurationComplete();
+
+        rootLogger.info("Test message 5");
+        testLogger.severe("Test message 6");
+        randomLogger.log(Level.TRACE, "Test message 7");
+
+        Assert.assertEquals(7, TestHandler.MESSAGES.size());
+
+        // Test the messages actually logged
+        Assert.assertEquals("Test message 1", TestHandler.MESSAGES.get(0).getFormattedMessage());
+        Assert.assertEquals("Test message 2", TestHandler.MESSAGES.get(1).getFormattedMessage());
+        Assert.assertEquals("Test message 3", TestHandler.MESSAGES.get(2).getFormattedMessage());
+        Assert.assertEquals("Test message 4", TestHandler.MESSAGES.get(3).getFormattedMessage());
+        Assert.assertEquals("Test message 5", TestHandler.MESSAGES.get(4).getFormattedMessage());
+        Assert.assertEquals("Test message 6", TestHandler.MESSAGES.get(5).getFormattedMessage());
+        Assert.assertEquals("Test message 7", TestHandler.MESSAGES.get(6).getFormattedMessage());
+    }
+
+    @Test
+    public void testBootstrapConfiguredLevelNotLogged() {
+        final LogContext logContext = LogContext.create(BootstrapConfiguration.create(true).useConsoleHandler().setLogLevel(Level.TRACE));
+
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.info("Test message 1");
+        rootLogger.fine("Test message 2");
+
+        final Logger testLogger = logContext.getLogger(BootstrapLoggingTests.class.getName());
+        testLogger.warning("Test message 3");
+
+        final Logger randomLogger = logContext.getLogger(UUID.randomUUID().toString());
+        randomLogger.severe("Test message 4");
+
+        final TestHandler handler = new TestHandler();
+        rootLogger.addHandler(handler);
+        // Set the root logger level to INFO as it will have been set to TRACE in bootstrapping
+        rootLogger.setLevel(Level.INFO);
+        logContext.configurationComplete();
+
+        rootLogger.info("Test message 5");
+        testLogger.severe("Test message 6");
+        randomLogger.log(Level.TRACE, "Test message 7");
+
+        // FINE and TRACE levels should not be logged
+        Assert.assertEquals(5, TestHandler.MESSAGES.size());
+
+        // Test the messages actually logged
+        Assert.assertEquals("Test message 1", TestHandler.MESSAGES.get(0).getFormattedMessage());
+        Assert.assertEquals("Test message 3", TestHandler.MESSAGES.get(1).getFormattedMessage());
+        Assert.assertEquals("Test message 4", TestHandler.MESSAGES.get(2).getFormattedMessage());
+        Assert.assertEquals("Test message 5", TestHandler.MESSAGES.get(3).getFormattedMessage());
+        Assert.assertEquals("Test message 6", TestHandler.MESSAGES.get(4).getFormattedMessage());
+    }
+
+    @Test
+    public void testBootstrapConfiguredLevelLogged() {
+        final LogContext logContext = LogContext.create(BootstrapConfiguration.create(true).useConsoleHandler().setLogLevel(Level.TRACE));
+
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.info("Test message 1");
+        rootLogger.fine("Test message 2");
+
+        final Logger testLogger = logContext.getLogger(BootstrapLoggingTests.class.getName());
+        testLogger.warning("Test message 3");
+
+        final Logger randomLogger = logContext.getLogger(UUID.randomUUID().toString());
+        randomLogger.setLevel(Level.TRACE);
+        randomLogger.severe("Test message 4");
+
+        final TestHandler handler = new TestHandler();
+        rootLogger.addHandler(handler);
+        // Set the root logger level to INFO as it will have been set to TRACE in bootstrapping
+        rootLogger.setLevel(Level.INFO);
+        logContext.configurationComplete();
+
+        rootLogger.info("Test message 5");
+        testLogger.severe("Test message 6");
+        randomLogger.log(Level.TRACE, "Test message 7");
+
+        // FINE and TRACE levels should not be logged
+        Assert.assertEquals(6, TestHandler.MESSAGES.size());
+
+        // Test the messages actually logged
+        Assert.assertEquals("Test message 1", TestHandler.MESSAGES.get(0).getFormattedMessage());
+        Assert.assertEquals("Test message 3", TestHandler.MESSAGES.get(1).getFormattedMessage());
+        Assert.assertEquals("Test message 4", TestHandler.MESSAGES.get(2).getFormattedMessage());
+        Assert.assertEquals("Test message 5", TestHandler.MESSAGES.get(3).getFormattedMessage());
+        Assert.assertEquals("Test message 6", TestHandler.MESSAGES.get(4).getFormattedMessage());
+        Assert.assertEquals("Test message 7", TestHandler.MESSAGES.get(5).getFormattedMessage());
+    }
+
+    @Test
+    public void testBootstrapAllLoggedAfterComplete() throws Exception {
+        final ExecutorService service = Executors.newFixedThreadPool(ProcessorInfo.availableProcessors() * 2);
+        final LogContext logContext = LogContext.create(BootstrapConfiguration.create(true).useConsoleHandler());
+
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.addHandler(new TestHandler());
+
+        try {
+            for (int i = 0; i < ITERATIONS; i++) {
+                final int current = i;
+                service.submit(() -> rootLogger.info(Integer.toString(current)));
+            }
+            // Wait until all the messages have been logged before
+            service.shutdown();
+            service.awaitTermination(20, TimeUnit.SECONDS);
+            logContext.configurationComplete();
+
+            // Test that all messages have been flushed to the handler
+            Assert.assertEquals(ITERATIONS, TestHandler.MESSAGES.size());
+
+        } finally {
+            Assert.assertTrue(service.shutdownNow().isEmpty());
+        }
+    }
+
+    @Test
+    public void testBootstrapAllLoggedMidComplete() throws Exception {
+        final ExecutorService service = Executors.newFixedThreadPool(ProcessorInfo.availableProcessors() * 2);
+        final LogContext logContext = LogContext.create(BootstrapConfiguration.create(true).useConsoleHandler());
+
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.addHandler(new TestHandler());
+        final Random r = new Random();
+
+        try {
+            for (int i = 0; i < ITERATIONS; i++) {
+                final int current = i;
+                service.submit(() -> {
+                    TimeUnit.MILLISECONDS.sleep(r.nextInt(15));
+                    rootLogger.info(Integer.toString(current));
+                    return null;
+                });
+            }
+            // Wait for a short time to make sure some messages are logged before we commit
+            TimeUnit.MILLISECONDS.sleep(150L);
+            logContext.configurationComplete();
+            // Wait until all the messages have been logged before
+            service.shutdown();
+            service.awaitTermination(5, TimeUnit.SECONDS);
+
+            // Test that all messages have been flushed to the handler
+            final List<Integer> missing = new ArrayList<>(ITERATIONS);
+            for (int i = 0; i < ITERATIONS; i++) {
+                missing.add(i);
+            }
+
+            final List<Integer> ints = TestHandler.MESSAGES.stream()
+                    .map(extLogRecord -> Integer.parseInt(extLogRecord.getFormattedMessage()))
+                    .collect(Collectors.toList());
+            missing.removeAll(ints);
+            Collections.sort(missing);
+            Assert.assertEquals(String.format("Missing the following entries: %s", missing), ITERATIONS, TestHandler.MESSAGES.size());
+
+        } finally {
+            Assert.assertTrue(service.shutdownNow().isEmpty());
+        }
+    }
+
+    @Test
+    public void testBootstrapOrder() throws Exception {
+        final List<String> expected = new ArrayList<>(ITERATIONS);
+        final ExecutorService service = Executors.newFixedThreadPool(ProcessorInfo.availableProcessors() * 2);
+        final LogContext logContext = LogContext.create(BootstrapConfiguration.create(true).useConsoleHandler());
+
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.addHandler(new TestHandler());
+        final Random r = new Random();
+
+        try {
+            for (int i = 0; i < ITERATIONS; i++) {
+                final int current = i;
+                service.submit(() -> {
+                    TimeUnit.MILLISECONDS.sleep(r.nextInt(15));
+                    final String msg = Integer.toString(current);
+                    // Need to synchronize to ensure order of the logged messages and the expected messages
+                    synchronized (expected) {
+                        expected.add(msg);
+                        rootLogger.info(msg);
+                    }
+                    return null;
+                });
+            }
+            // Wait for a short time to make sure some messages are logged before we commit
+            TimeUnit.MILLISECONDS.sleep(150L);
+            logContext.configurationComplete();
+            // Wait until all the messages have been logged before
+            service.shutdown();
+            service.awaitTermination(5, TimeUnit.SECONDS);
+
+            // Get the current messages from the handler
+            final List<String> found = TestHandler.MESSAGES.stream()
+                    .map(ExtLogRecord::getFormattedMessage)
+                    .collect(Collectors.toList());
+            final List<String> missing = new ArrayList<>(expected);
+            missing.removeAll(found);
+            Assert.assertTrue("Missing the following entries: " + missing, missing.isEmpty());
+
+            // This shouldn't happen as the above should find it, but it's better to fail here than below.
+            Assert.assertEquals(expected.size(), TestHandler.MESSAGES.size());
+
+            // Now we need to test the order of what we have vs what is expected. These should be in the same order
+            for (int i = 0; i < expected.size(); i++) {
+                final String expectedMessage = expected.get(i);
+                final ExtLogRecord record = TestHandler.MESSAGES.get(i);
+                Assert.assertEquals(expectedMessage, record.getFormattedMessage());
+            }
+
+        } finally {
+            Assert.assertTrue(service.shutdownNow().isEmpty());
+        }
+    }
+
+    public static class TestHandler extends ExtHandler {
+        static final List<ExtLogRecord> MESSAGES = new ArrayList<>();
+
+        @Override
+        protected synchronized void doPublish(final ExtLogRecord record) {
+            super.doPublish(record);
+            MESSAGES.add(record);
+        }
+
+        @Override
+        public void close() throws SecurityException {
+            super.close();
+            MESSAGES.clear();
+        }
+    }
+}


### PR DESCRIPTION
…ed messages on a LogContext will be queued until the LogContext.configurationComplete() method is invoked.

By default bootstrapping is disabled. It can either be enabled with a system property or by using the BootstrapConfiguration API when creating a LogContext.

https://issues.jboss.org/browse/LOGMGR-177

# How it works

## Overview
If bootstrapping is enabled log messages will be queued until the `LogContext.configurationComplete()` method is invoked. At this point log messages will be replayed and logged as normal.

## `LogRecordPublisher` API
This PR introduces a new `LogRecordPublisher`. This new API replaces the `LoggerNode.publish()` method.

## Bootstrap
There are two new objects to define bootstrapping. The first is `BootstrapConfiguration` which is a public facing API. This API can be used to configure how bootstrapping is handled. By default this will be controlled by system properties, but these properties can be overridden with the `BootstrapConfiguration` APII.

The second is `Bootstrap` which is an internal API used to queue log messages until the `LogContext.configurationComplete()` is invoked. A `Bootstrap` instance is optionally assigned to each `LogContext` if bootstrapping is enabled. The `LogContext.configurationComplete()` invokes the `Bootstrap.complete()` which drains the queued log messages to a default `LogRecordPublisher`. It then replaces the publisher on each child `LoggerNode` with the default publisher. Currently only the root-logger is "bootstrapped".

## Termination
A shutdown hook is registered which will be invoked if the `Bootstrap.complete()` is not invoked before the JVM terminates. This will drain the queue to a defined handler or if all else fails `stderr`.

## Caveats
One caveat is when the bootstrap level is changed it changes the level on the root logger. A user would need to ensure they change the root logger level to the level they desire just before the `LogContext.configurationComplete()`. Configuration order of loggers is important here where the root logger is always configured last.

# Benchmarks

I've done some benchmark testing to ensure the performance impact is not massive. The first benchmark was run against 2.1.0.Alpha5. The second was run against 2.1.0.Alpha6-SNAPSHOT with this PR.

What happens in the bootstrapped benchmark is a message is logged 50 times. The `LogContext.configurationComplete()` is invoked then another 50 messages are logged.

## No bootstrap configuration available
```
Benchmark                            Mode  Cnt    Score   Error  Units
LoggerBenchmark.logInfoAndDebug      avgt  200  194.034 ± 3.163  ns/op
LoggerBenchmark.logInfoAndDebug_100  avgt  200  176.709 ± 4.211  ns/op
```

## Bootstrapped
```
Benchmark                                                      Mode  Cnt     Score     Error  Units
BootstrapLoggingBenchmark.bootstrapDisabled                    avgt  200   115.032 ±   2.123  ns/op
BootstrapLoggingBenchmark.bootstrapEnabled                     avgt  200  4281.822 ± 172.889  ns/op
BootstrapLoggingBenchmark.bootstrapEnabledCallerDisabled       avgt  200   161.165 ±  11.796  ns/op
BootstrapLoggingBenchmark.bootstrapEnabledCallerDisabledDebug  avgt  200   161.631 ±  12.770  ns/op
BootstrapLoggingBenchmark.bootstrapEnabledDebug                avgt  200  4309.208 ± 190.343  ns/op
```
Obviously the performance is much better when running with the caller calculation disabled. Other than that it seems to perform about the same. The extra time spent is likely when records are being taken from the queue and pushed to through the publish again.