### PR TITLE
[LOGMGR-187] The ClassLoaderLogContextSelector should keep searching …

### DIFF
--- a/src/main/java/org/jboss/logmanager/JDKSpecific.java
+++ b/src/main/java/org/jboss/logmanager/JDKSpecific.java
@@ -21,6 +21,9 @@ package org.jboss.logmanager;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.jboss.modules.Module;
@@ -63,6 +66,17 @@ final class JDKSpecific {
             }
         }
         return null;
+    }
+
+    static Collection<Class<?>> findCallingClasses(Set<ClassLoader> rejectClassLoaders) {
+        final Collection<Class<?>> result = new LinkedHashSet<>();
+        for (Class<?> caller : GATEWAY.getClassContext()) {
+            final ClassLoader classLoader = caller.getClassLoader();
+            if (classLoader != null && ! rejectClassLoaders.contains(classLoader)) {
+                result.add(caller);
+            }
+        }
+        return result;
     }
 
     static void calculateCaller(ExtLogRecord logRecord) {


### PR DESCRIPTION
…the call stack to find a log context.

In previous versions of the `ClassLoaderLogContextSelector` the entire call stack was searched. #160 introduced the `JDKSpecific` which short circuits when it finds the first matching class. That short circuits too early for this selector and it's the reason the `CallerClassLoaderLogContextSelector` was introduced.

This PR adds a new `Collection<Class<?>> findCallingClasses(Set<ClassLoader> rejectClassLoaders)` method to allow all valid callers to be returned.