### PR TITLE
[LOGMGR-177] Add a delayed handler which can optionally queue message…

### DIFF
--- a/src/main/java/org/jboss/logmanager/config/LogContextConfiguration.java
+++ b/src/main/java/org/jboss/logmanager/config/LogContextConfiguration.java
@@ -22,12 +22,14 @@ package org.jboss.logmanager.config;
 import java.util.List;
 
 import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.handlers.DelayedHandler;
 
 /**
  * A log context configuration.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
+@SuppressWarnings("unused")
 public interface LogContextConfiguration {
 
     /**
@@ -146,6 +148,14 @@ public interface LogContextConfiguration {
      * Clear all the current changes and restore this object to its original state.
      */
     void forget();
+
+    /**
+     * Activates any {@linkplain DelayedHandler#activate() handlers} that require activation. This should likely only
+     * be invoked after a {@link #prepare()}, {@link #commit()} or {@link #forget()}.
+     */
+    default void activate() {
+        // Do nothing by default for backwards compatibility
+    }
 
     /**
      * The factory class for persistent configurations.

--- a/src/main/java/org/jboss/logmanager/config/LogContextConfigurationImpl.java
+++ b/src/main/java/org/jboss/logmanager/config/LogContextConfigurationImpl.java
@@ -43,6 +43,7 @@ import org.jboss.logmanager.filters.LevelFilter;
 import org.jboss.logmanager.filters.LevelRangeFilter;
 import org.jboss.logmanager.filters.RegexFilter;
 import org.jboss.logmanager.filters.SubstituteFilter;
+import org.jboss.logmanager.handlers.DelayedHandler;
 
 import java.util.logging.ErrorManager;
 import java.util.logging.Filter;
@@ -297,6 +298,15 @@ final class LogContextConfigurationImpl implements LogContextConfiguration {
             prepare();
         }
         clear();
+    }
+
+    @Override
+    public void activate() {
+        for (Handler handler : getHandlerRefs().values()) {
+            if (handler instanceof DelayedHandler) {
+                ((DelayedHandler) handler).activate();
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/jboss/logmanager/handlers/DelayedHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/DelayedHandler.java
@@ -1,0 +1,147 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager.handlers;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.ExtHandler;
+import org.jboss.logmanager.ExtLogRecord;
+
+/**
+ * A handler that queues messages until it's {@linkplain #activate() activated}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+public abstract class DelayedHandler extends ExtHandler {
+
+    protected final Object outputLock = new Object();
+
+    private final Deque<ExtLogRecord> logRecords = new ArrayDeque<>();
+
+    private volatile boolean activated = false;
+
+    @Override
+    public final void publish(final LogRecord record) {
+        if (isEnabled() && record != null) {
+            publish(ExtLogRecord.wrap(record));
+        }
+    }
+
+    @Override
+    public final void publish(final ExtLogRecord record) {
+        if (isEnabled() && record != null) {
+            if (activated) {
+                doPublish(record);
+            } else {
+                synchronized (outputLock) {
+                    // Check one more time to see if we've been activated before queuing the messages
+                    if (activated) {
+                        doPublish(record);
+                    } else if (isAutoActivate()) {
+                        activate();
+                        doPublish(record);
+                    } else {
+                        if (isCallerCalculationRequired()) {
+                            record.copyAll();
+                        } else {
+                            // Disable the caller calculation since it's been determined we won't be using it
+                            record.disableCallerCalculation();
+                            // Copy the MDC over
+                            record.copyMdc();
+                            // In case serialization is required
+                            record.getFormattedMessage();
+                        }
+                        logRecords.addLast(record);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public final void close() throws SecurityException {
+        checkAccess(this);
+        synchronized (outputLock) {
+            activated = false;
+        }
+        closeResources();
+        super.close();
+    }
+
+    /**
+     * Activates the handler. Once activation is complete queued messages will be published to the handler.
+     */
+    public final void activate() {
+        synchronized (outputLock) {
+            // Only activate if required
+            if (requiresActivation()) {
+                doActivation();
+            }
+            // Always attempt to drain the queue
+            ExtLogRecord record;
+            while ((record = logRecords.pollFirst()) != null) {
+                if (isEnabled() && isLoggable(record)) {
+                    doPublish(record);
+                }
+            }
+            activated = true;
+        }
+    }
+
+    /**
+     * Indicates whether or not this handler has been {@linkplain #activate() activated}.
+     *
+     * @return {@code true} if the handler has been activated, otherwise {@code false}
+     */
+    public final boolean isActivated() {
+        return activated;
+    }
+
+    /**
+     * Indicates whether or not this handler should be automatically activated when the first record is written.
+     *
+     * @return {@code true} if the handler will be automatically activated, otherwise {@code false} if
+     * {@link #activate()} is required to be explicitly invoked
+     */
+    public abstract boolean isAutoActivate();
+
+    /**
+     * Handles closing any internal resources.
+     */
+    protected abstract void closeResources();
+
+    /**
+     * Indicates whether or not activation is required. {@linkplain #doActivation() Activation} will only be invoked
+     * if {@code true} is returned.
+     *
+     * @return {@code true} if {@linkplain #doActivation() activation} should be done, otherwise {@code false}
+     */
+    protected abstract boolean requiresActivation();
+
+    /**
+     * Handles activating the handler. Once activation is complete queued messages will be published to the handler.
+     */
+    protected void doActivation() {
+        // do nothing by default
+    }
+}

--- a/src/main/java/org/jboss/logmanager/handlers/SocketHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/SocketHandler.java
@@ -33,16 +33,20 @@ import java.util.logging.Formatter;
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
 
-import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
 
 /**
  * A handler used to communicate over a socket.
+ * <p>
+ * By default this handler will {@linkplain #isAutoActivate() automatically activate} itself. If messages need to be
+ * queued until the handler is appropriately configured the {@linkplain #setAutoActivate(boolean) automatic activation}
+ * should be set to {@code false}.
+ * </p>
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
-public class SocketHandler extends ExtHandler {
+public class SocketHandler extends DelayedHandler {
 
     /**
      * The type of socket
@@ -62,12 +66,7 @@ public class SocketHandler extends ExtHandler {
         SSL_TCP,
     }
 
-    @SuppressWarnings("WeakerAccess")
     public static final int DEFAULT_PORT = 4560;
-
-    private final boolean configureSocketFactory;
-
-    private final Object outputLock = new Object();
 
     // All the following fields are guarded by outputLock
     private SocketFactory socketFactory;
@@ -77,6 +76,7 @@ public class SocketHandler extends ExtHandler {
     private boolean blockOnReconnect;
     private Writer writer;
     private boolean initialize;
+    private boolean autoActivate;
 
     /**
      * Creates a socket handler with an address of {@linkplain java.net.InetAddress#getLocalHost() localhost} and port
@@ -141,6 +141,22 @@ public class SocketHandler extends ExtHandler {
      *                      {@linkplain Protocol#SSL_TCP SSL TCP} connections, if {@code null} a default factory will
      *                      be used
      * @param protocol      the protocol to connect with
+     * @param hostname      the hostname to connect to
+     * @param port          the port to connect to
+     *
+     * @throws UnknownHostException if an error occurs resolving the hostname
+     */
+    public SocketHandler(final SocketFactory socketFactory, final Protocol protocol, final String hostname, final int port) throws UnknownHostException {
+        this(socketFactory, protocol, InetAddress.getByName(hostname), port);
+    }
+
+    /**
+     * Creates a socket handler.
+     *
+     * @param socketFactory the socket factory to use for creating {@linkplain Protocol#TCP TCP} or
+     *                      {@linkplain Protocol#SSL_TCP SSL TCP} connections, if {@code null} a default factory will
+     *                      be used
+     * @param protocol      the protocol to connect with
      * @param address       the address to connect to
      * @param port          the port to connect to
      */
@@ -151,8 +167,8 @@ public class SocketHandler extends ExtHandler {
         initialize = true;
         writer = null;
         this.socketFactory = socketFactory;
-        configureSocketFactory = (socketFactory == null);
         blockOnReconnect = false;
+        autoActivate = true;
     }
 
     @Override
@@ -195,13 +211,19 @@ public class SocketHandler extends ExtHandler {
     }
 
     @Override
-    public void close() throws SecurityException {
-        checkAccess(this);
+    protected void closeResources() {
         synchronized (outputLock) {
             safeClose(writer);
             writer = null;
+            initialize = true;
         }
-        super.close();
+    }
+
+    @Override
+    protected boolean requiresActivation() {
+        synchronized (outputLock) {
+            return initialize;
+        }
     }
 
     /**
@@ -223,6 +245,27 @@ public class SocketHandler extends ExtHandler {
         synchronized (outputLock) {
             this.address = address;
             initialize = true;
+        }
+    }
+
+    @Override
+    public boolean isAutoActivate() {
+        synchronized (outputLock) {
+            return autoActivate;
+        }
+    }
+
+    /**
+     * Sets whether or not the handler should be {@linkplain #activate() activated} when the first record is written.
+     * If set to {@code false} {@link #activate()} is required to be invoked explicitly.
+     *
+     * @param autoActivate {@code true} if {@link #activate()} should be automatically invoked, otherwise
+     *                     {@code false} if {@link #activate()} should be explicitly invoked
+     */
+    public void setAutoActivate(final boolean autoActivate) {
+        checkAccess(this);
+        synchronized (outputLock) {
+            this.autoActivate = autoActivate;
         }
     }
 
@@ -276,17 +319,22 @@ public class SocketHandler extends ExtHandler {
     }
 
     /**
-     * Sets the protocol to use.
+     * Sets the protocol to use. If the value is {@code null} the protocol will be set to
+     * {@linkplain Protocol#TCP TCP}.
+     * <p>
+     * Note that is resets the {@linkplain #setSocketFactory(SocketFactory) socket factory}.
+     * </p>
      *
      * @param protocol the protocol to use
      */
     public void setProtocol(final Protocol protocol) {
         checkAccess(this);
         synchronized (outputLock) {
-            // If the socket factory wasn't set, we may need to configure the correct factory
-            if (configureSocketFactory && this.protocol != protocol) {
-                socketFactory = null;
+            if (protocol == null) {
+                this.protocol = Protocol.TCP;
             }
+            // Reset the socket factory
+            socketFactory = null;
             this.protocol = protocol;
             initialize = true;
         }
@@ -310,6 +358,24 @@ public class SocketHandler extends ExtHandler {
         checkAccess(this);
         synchronized (outputLock) {
             this.port = port;
+            initialize = true;
+        }
+    }
+
+    /**
+     * Sets the socket factory to use for creating {@linkplain Protocol#TCP TCP} or {@linkplain Protocol#SSL_TCP SSL}
+     * connections.
+     * <p>
+     * Note that if the {@linkplain #setProtocol(Protocol) protocol} is set the socket factory will be set to
+     * {@code null} and reset.
+     * </p>
+     *
+     * @param socketFactory the socket factory
+     */
+    public void setSocketFactory(final SocketFactory socketFactory) {
+        checkAccess(this);
+        synchronized (outputLock) {
+            this.socketFactory = socketFactory;
             initialize = true;
         }
     }
@@ -351,13 +417,19 @@ public class SocketHandler extends ExtHandler {
     private OutputStream createOutputStream() {
         if (address != null || port >= 0) {
             try {
-                if (protocol == Protocol.SSL_TCP) {
-                    return new SslTcpOutputStream(getSocketFactory(), address, port, blockOnReconnect);
-                } else if (protocol == Protocol.UDP) {
+                if (protocol == Protocol.UDP) {
                     return new UdpOutputStream(address, port);
-                } else {
-                    return new TcpOutputStream(getSocketFactory(), address, port, blockOnReconnect);
                 }
+                SocketFactory socketFactory = this.socketFactory;
+                if (socketFactory == null) {
+                    if (protocol == Protocol.SSL_TCP) {
+                        this.socketFactory = socketFactory = SSLSocketFactory.getDefault();
+                    } else {
+                        // Assume we want a TCP connection
+                        this.socketFactory = socketFactory = SocketFactory.getDefault();
+                    }
+                }
+                return new TcpOutputStream(socketFactory, address, port, blockOnReconnect);
             } catch (IOException e) {
                 reportError("Failed to create socket output stream", e, ErrorManager.OPEN_FAILURE);
             }
@@ -399,17 +471,5 @@ public class SocketHandler extends ExtHandler {
             reportError("Error on flush", e, ErrorManager.FLUSH_FAILURE);
         } catch (Throwable ignored) {
         }
-    }
-
-    private SocketFactory getSocketFactory() {
-        SocketFactory socketFactory = this.socketFactory;
-        if (socketFactory == null) {
-            if (protocol == Protocol.TCP) {
-                this.socketFactory = socketFactory = SocketFactory.getDefault();
-            } else if (protocol == Protocol.SSL_TCP) {
-                this.socketFactory = socketFactory = SSLSocketFactory.getDefault();
-            }
-        }
-        return socketFactory;
     }
 }

--- a/src/test/java/org/jboss/logmanager/handlers/DelayedHandlerTests.java
+++ b/src/test/java/org/jboss/logmanager/handlers/DelayedHandlerTests.java
@@ -1,0 +1,287 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager.handlers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.common.cpu.ProcessorInfo;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DelayedHandlerTests {
+
+    private static final int ITERATIONS = Integer.parseInt(System.getProperty("org.jboss.bootstrap.test.iterations", "1000"));
+
+    @After
+    public void cleanup() {
+        TestHandler.MESSAGES.clear();
+        TestHandler.ACTIVATION_COUNT.set(0);
+    }
+
+    @Test
+    public void testQueuedMessages() {
+        final LogContext logContext = LogContext.create();
+
+        final LogContextConfiguration logContextConfiguration = LogContextConfiguration.Factory.create(logContext);
+        final HandlerConfiguration handlerConfiguration = logContextConfiguration.addHandlerConfiguration(
+                null, TestHandler.class.getName(), "test-handler");
+        logContextConfiguration.addLoggerConfiguration("").addHandlerName(handlerConfiguration.getName());
+        logContextConfiguration.commit();
+
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.info("Test message 1");
+        rootLogger.fine("Test message 2");
+
+        final Logger testLogger = logContext.getLogger(DelayedHandlerTests.class.getName());
+        testLogger.warning("Test message 3");
+
+        final Logger randomLogger = logContext.getLogger("org.jboss.logmanager." + UUID.randomUUID());
+        randomLogger.severe("Test message 4");
+
+        // Activate after some messages have been logged
+        logContextConfiguration.activate();
+
+        rootLogger.info("Test message 5");
+        testLogger.severe("Test message 6");
+        randomLogger.finest("Test message 7");
+
+        // The default root logger message is INFO so FINE and FINEST should not be logged
+        Assert.assertEquals(5, TestHandler.MESSAGES.size());
+
+        // Test the messages actually logged
+        Assert.assertEquals("Test message 1", TestHandler.MESSAGES.get(0).getFormattedMessage());
+        Assert.assertEquals("Test message 3", TestHandler.MESSAGES.get(1).getFormattedMessage());
+        Assert.assertEquals("Test message 4", TestHandler.MESSAGES.get(2).getFormattedMessage());
+        Assert.assertEquals("Test message 5", TestHandler.MESSAGES.get(3).getFormattedMessage());
+        Assert.assertEquals("Test message 6", TestHandler.MESSAGES.get(4).getFormattedMessage());
+    }
+
+
+    @Test
+    public void testAllLoggedAfterActivation() throws Exception {
+        final ExecutorService service = createExecutor();
+        final LogContext logContext = LogContext.create();
+
+        final TestHandler handler = new TestHandler();
+        handler.setAutoActivate(false);
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.addHandler(handler);
+
+        try {
+            for (int i = 0; i < ITERATIONS; i++) {
+                final int current = i;
+                service.submit(() -> rootLogger.info(Integer.toString(current)));
+            }
+            // Wait until all the messages have been logged before
+            service.shutdown();
+            service.awaitTermination(5, TimeUnit.SECONDS);
+            handler.activate();
+
+            // Test that all messages have been flushed to the handler
+            Assert.assertEquals(ITERATIONS, TestHandler.MESSAGES.size());
+
+            // Test that all messages have been flushed to the handler
+            final List<Integer> missing = new ArrayList<>(ITERATIONS);
+            for (int i = 0; i < ITERATIONS; i++) {
+                missing.add(i);
+            }
+
+            final List<Integer> ints = TestHandler.MESSAGES.stream()
+                    .map(extLogRecord -> Integer.parseInt(extLogRecord.getFormattedMessage()))
+                    .collect(Collectors.toList());
+            missing.removeAll(ints);
+            Collections.sort(missing);
+            Assert.assertEquals(String.format("Missing the following entries: %s", missing), ITERATIONS, TestHandler.MESSAGES.size());
+
+        } finally {
+            Assert.assertTrue(service.shutdownNow().isEmpty());
+        }
+    }
+
+    @Test
+    public void testAllLoggedMidActivation() throws Exception {
+        final ExecutorService service = createExecutor();
+        final LogContext logContext = LogContext.create();
+
+        final TestHandler handler = new TestHandler();
+        handler.setAutoActivate(false);
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.addHandler(handler);
+        final Random r = new Random();
+
+        try {
+            for (int i = 0; i < ITERATIONS; i++) {
+                final int current = i;
+                service.submit(() -> {
+                    TimeUnit.MILLISECONDS.sleep(r.nextInt(15));
+                    rootLogger.info(Integer.toString(current));
+                    return null;
+                });
+            }
+            // Wait for a short time to make sure some messages are logged before we activate
+            TimeUnit.MILLISECONDS.sleep(150L);
+            handler.activate();
+            // Wait until all the messages have been logged before
+            service.shutdown();
+            service.awaitTermination(5, TimeUnit.SECONDS);
+
+            // Test that all messages have been flushed to the handler
+            final List<Integer> missing = new ArrayList<>(ITERATIONS);
+            for (int i = 0; i < ITERATIONS; i++) {
+                missing.add(i);
+            }
+
+            final List<Integer> ints = TestHandler.MESSAGES.stream()
+                    .map(extLogRecord -> Integer.parseInt(extLogRecord.getFormattedMessage()))
+                    .collect(Collectors.toList());
+            missing.removeAll(ints);
+            Collections.sort(missing);
+            Assert.assertEquals(String.format("Missing the following entries: %s", missing), ITERATIONS, TestHandler.MESSAGES.size());
+
+        } finally {
+            Assert.assertTrue(service.shutdownNow().isEmpty());
+        }
+    }
+
+    @Test
+    public void testOrder() throws Exception {
+        final List<String> expected = new ArrayList<>(ITERATIONS);
+        final ExecutorService service = createExecutor();
+        final LogContext logContext = LogContext.create();
+
+        final TestHandler handler = new TestHandler();
+        handler.setAutoActivate(false);
+        final Logger rootLogger = logContext.getLogger("");
+        rootLogger.addHandler(handler);
+        final Random r = new Random();
+
+        try {
+            for (int i = 0; i < ITERATIONS; i++) {
+                final int current = i;
+                service.submit(() -> {
+                    TimeUnit.MILLISECONDS.sleep(r.nextInt(15));
+                    final String msg = Integer.toString(current);
+                    // Need to synchronize to ensure order of the logged messages and the expected messages
+                    synchronized (expected) {
+                        expected.add(msg);
+                        rootLogger.info(msg);
+                    }
+                    return null;
+                });
+            }
+            // Wait for a short time to make sure some messages are logged before we commit
+            TimeUnit.MILLISECONDS.sleep(150L);
+            handler.activate();
+            // Wait until all the messages have been logged before
+            service.shutdown();
+            service.awaitTermination(5, TimeUnit.SECONDS);
+
+            // Get the current messages from the handler
+            final List<String> found = TestHandler.MESSAGES.stream()
+                    .map(ExtLogRecord::getFormattedMessage)
+                    .collect(Collectors.toList());
+            final List<String> missing = new ArrayList<>(expected);
+            missing.removeAll(found);
+            Assert.assertTrue("Missing the following entries: " + missing, missing.isEmpty());
+
+            // This shouldn't happen as the above should find it, but it's better to fail here than below.
+            Assert.assertEquals(expected.size(), TestHandler.MESSAGES.size());
+
+            // Now we need to test the order of what we have vs what is expected. These should be in the same order
+            for (int i = 0; i < expected.size(); i++) {
+                final String expectedMessage = expected.get(i);
+                final ExtLogRecord record = TestHandler.MESSAGES.get(i);
+                Assert.assertEquals(expectedMessage, record.getFormattedMessage());
+            }
+
+        } finally {
+            Assert.assertTrue(service.shutdownNow().isEmpty());
+        }
+    }
+
+    private static ExecutorService createExecutor() {
+        return Executors.newFixedThreadPool(ProcessorInfo.availableProcessors() * 2);
+    }
+
+    public static class TestHandler extends DelayedHandler {
+        static final List<ExtLogRecord> MESSAGES = new ArrayList<>();
+        static final AtomicInteger ACTIVATION_COUNT = new AtomicInteger();
+
+        private boolean autoActivate;
+
+        @SuppressWarnings("WeakerAccess")
+        public TestHandler() {
+            autoActivate = true;
+        }
+
+        @Override
+        protected synchronized void doPublish(final ExtLogRecord record) {
+            MESSAGES.add(record);
+        }
+
+        @Override
+        protected void closeResources() throws SecurityException {
+            MESSAGES.clear();
+            ACTIVATION_COUNT.set(0);
+        }
+
+        @Override
+        protected boolean requiresActivation() {
+            return true;
+        }
+
+        @Override
+        protected void doActivation() {
+            ACTIVATION_COUNT.incrementAndGet();
+        }
+
+        @Override
+        public boolean isAutoActivate() {
+            synchronized (outputLock) {
+                return autoActivate;
+            }
+        }
+
+        void setAutoActivate(final boolean autoActivate) {
+            checkAccess(this);
+            synchronized (outputLock) {
+                this.autoActivate = autoActivate;
+            }
+        }
+    }
+}


### PR DESCRIPTION
…s until activated. Add a way to activate these handlers from the configuration API.

https://issues.jboss.org/browse/LOGMGR-177

# Overview
Introduce a new abstract handler that will optionally queue messages until the handler has been activated. Handlers should also have a way to automatically activate for cases where additional settings may not be required.

The main use case for this are handlers that communicate over a socket and would require an Elytron `SSLContext` in WildFly. These handlers would not be fully operational until the capability in WildFly is available. In cases where it's a non-TLS connection, these could be activated automatically and not require the logging subsystem or Elytron to be available or really even exist.

# Implementation
Both the `SocketHandler` and the `SyslogHandler` will implement this new abstract handler. By default this handlers will automatically activate. However they can be set to explicitly require activation.

The `LogContextConfiguration` API adds the ability to activate these handlers via the `LogContextConfiguration.activate()` method. This is done in cases where the configuration API is used and no direct access to the handlers is available. There is also a chance if a user has several handlers this could have a slight performance impact. However the simple workaround is just to not use several handlers on the same log context.

If activation is not automatic, then the `DelayedHandler.activate()` or `LogContextConfiguration.activate()` must explicitly be invoked.