### PR TITLE
[LOGMGR-188] Add option for generic properties and child handler name…

### DIFF
--- a/src/main/java/org/jboss/logmanager/config/ConfigurationProperty.java
+++ b/src/main/java/org/jboss/logmanager/config/ConfigurationProperty.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager.config;
+
+/**
+ * Represents a configuration property.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface ConfigurationProperty {
+
+    /**
+     * Indicates whether or not the property should be perisisted to the configuration.
+     *
+     * @return {@code true} if the property should be persisted, otherwise {@code false}
+     */
+    boolean isPersistable();
+
+    /**
+     * The key for the property.
+     *
+     * @return the key
+     */
+    String getKey();
+
+    /**
+     * The properties value.
+     *
+     * @return the value
+     */
+    ValueExpression<String> getValue();
+
+    /**
+     * The properties value which may or may not be an expression. If {@code allowExpression} is {@code false} a
+     * string representation of the {@linkplain ValueExpression#getResolvedValue() resolved value} will be returned.
+     * Otherwise a string which may be an expression will be returned.
+     *
+     * @param allowExpression {@code true} if a possible expression is allowed to be returned {@code false} if any
+     *                        possible expressions should be resovled
+     *
+     * @return a string representation of the value
+     *
+     * @see ValueExpression#getValue()
+     */
+    default String getValue(final boolean allowExpression) {
+        final ValueExpression<String> value = getValue();
+        if (value == null) {
+            return "";
+        }
+        return allowExpression ? value.getValue() : value.getResolvedValue();
+    }
+}

--- a/src/main/java/org/jboss/logmanager/config/ConfigurationPropertyImpl.java
+++ b/src/main/java/org/jboss/logmanager/config/ConfigurationPropertyImpl.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager.config;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class ConfigurationPropertyImpl implements ConfigurationProperty {
+
+    private final String key;
+    private final ValueExpression<String> value;
+    private final boolean writable;
+
+    ConfigurationPropertyImpl(final String key, final ValueExpression<String> value, final boolean writable) {
+        this.key = key;
+        this.value = value == null ? ValueExpression.NULL_STRING_EXPRESSION : value;
+        this.writable = writable;
+    }
+
+    @Override
+    public boolean isPersistable() {
+        return writable;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public ValueExpression<String> getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/jboss/logmanager/config/HandlerConfiguration.java
+++ b/src/main/java/org/jboss/logmanager/config/HandlerConfiguration.java
@@ -172,4 +172,21 @@ public interface HandlerConfiguration extends HandlerContainingConfigurable, Nam
      * @see ValueExpression
      */
     void setErrorManagerName(String expression, String value);
+
+    /**
+     * Indicates whether or not the handler names should be persisted to the configuration.
+     *
+     * @return {@code true} if the handler names should be persisted, otherwise {@code false}
+     */
+    default boolean isHandlerNamesPersistable() {
+        return true;
+    }
+
+    /**
+     * Sets whether or not the handler names should be persisted to the configuration.
+     *
+     * @param persistable {@code true} if the handler names should be persisted, otherwise {@code false}
+     */
+    default void setHandlerNamesPersistable(final boolean persistable) {
+    }
 }

--- a/src/main/java/org/jboss/logmanager/config/HandlerConfigurationImpl.java
+++ b/src/main/java/org/jboss/logmanager/config/HandlerConfigurationImpl.java
@@ -46,6 +46,7 @@ final class HandlerConfigurationImpl extends AbstractPropertyConfiguration<Handl
     private ValueExpression<String> filter;
     private ValueExpression<String> encoding;
     private ValueExpression<String> errorManagerName;
+    private boolean handlerNamesPersistable = true;
 
     HandlerConfigurationImpl(final LogContextConfigurationImpl configuration, final String name, final String moduleName, final String className, final String[] constructorProperties) {
         super(Handler.class, configuration, configuration.getHandlerRefs(), configuration.getHandlerConfigurations(), name, moduleName, className, constructorProperties);
@@ -395,6 +396,16 @@ final class HandlerConfigurationImpl extends AbstractPropertyConfiguration<Handl
             }
         });
         return true;
+    }
+
+    @Override
+    public boolean isHandlerNamesPersistable() {
+        return handlerNamesPersistable;
+    }
+
+    @Override
+    public void setHandlerNamesPersistable(final boolean persistable) {
+        this.handlerNamesPersistable = persistable;
     }
 
     String getDescription() {

--- a/src/main/java/org/jboss/logmanager/config/LogContextConfiguration.java
+++ b/src/main/java/org/jboss/logmanager/config/LogContextConfiguration.java
@@ -19,6 +19,7 @@
 
 package org.jboss.logmanager.config;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.logmanager.LogContext;
@@ -68,6 +69,22 @@ public interface LogContextConfiguration {
 
     List<String> getHandlerNames();
 
+    /**
+     * Returns a list of handler names that can be persisted to a configuration.
+     *
+     * @return the persistable handler names
+     */
+    default List<String> getPersistableHandlerNames() {
+        final List<String> handlerNames = new ArrayList<>();
+        for (String name : getHandlerNames()) {
+            final HandlerConfiguration config = getHandlerConfiguration(name);
+            if (config != null && config.isPersistable()) {
+                handlerNames.add(name);
+            }
+        }
+        return handlerNames;
+    }
+
     FormatterConfiguration addFormatterConfiguration(String moduleName, String className, String formatterName, String... constructorProperties);
 
     boolean removeFormatterConfiguration(String formatterName);
@@ -75,6 +92,22 @@ public interface LogContextConfiguration {
     FormatterConfiguration getFormatterConfiguration(String formatterName);
 
     List<String> getFormatterNames();
+
+    /**
+     * Returns a list of formatter names that can be persisted to a configuration.
+     *
+     * @return the persistable formatter names
+     */
+    default List<String> getPersistableFormatterNames() {
+        final List<String> formatterNames = new ArrayList<>();
+        for (String name : getFilterNames()) {
+            final FormatterConfiguration config = getFormatterConfiguration(name);
+            if (config != null && config.isPersistable()) {
+                formatterNames.add(name);
+            }
+        }
+        return formatterNames;
+    }
 
     FilterConfiguration addFilterConfiguration(String moduleName, String className, String filterName, String... constructorProperties);
 
@@ -84,6 +117,22 @@ public interface LogContextConfiguration {
 
     List<String> getFilterNames();
 
+    /**
+     * Returns a list of filter names that can be persisted to a configuration.
+     *
+     * @return the persistable filter names
+     */
+    default List<String> getPersistableFilterNames() {
+        final List<String> filterNames = new ArrayList<>();
+        for (String name : getFilterNames()) {
+            final FilterConfiguration config = getFilterConfiguration(name);
+            if (config != null && config.isPersistable()) {
+                filterNames.add(name);
+            }
+        }
+        return filterNames;
+    }
+
     ErrorManagerConfiguration addErrorManagerConfiguration(String moduleName, String className, String errorManagerName, String... constructorProperties);
 
     boolean removeErrorManagerConfiguration(String errorManagerName);
@@ -91,6 +140,22 @@ public interface LogContextConfiguration {
     ErrorManagerConfiguration getErrorManagerConfiguration(String errorManagerName);
 
     List<String> getErrorManagerNames();
+
+    /**
+     * Returns a list of error manager names that can be persisted to a configuration.
+     *
+     * @return the persistable error manager names
+     */
+    default List<String> getPersistableErrorManagerNames() {
+        final List<String> errorManagerNames = new ArrayList<>();
+        for (String name : getErrorManagerNames()) {
+            final ErrorManagerConfiguration config = getErrorManagerConfiguration(name);
+            if (config != null && config.isPersistable()) {
+                errorManagerNames.add(name);
+            }
+        }
+        return errorManagerNames;
+    }
 
     /**
      * Prepares the current changes. The changes are applied into the running logging configuration, but can be rolled
@@ -136,6 +201,22 @@ public interface LogContextConfiguration {
      * @return a list of the names
      */
     List<String> getPojoNames();
+
+    /**
+     * Returns a list of POJO names that can be persisted to a configuration.
+     *
+     * @return the persistable POJO names
+     */
+    default List<String> getPersistablePojoNames() {
+        final List<String> pojoNames = new ArrayList<>();
+        for (String name : getPojoNames()) {
+            final PojoConfiguration config = getPojoConfiguration(name);
+            if (config != null && config.isPersistable()) {
+                pojoNames.add(name);
+            }
+        }
+        return pojoNames;
+    }
 
     /**
      * Commit the current changes into the running logging configuration.

--- a/src/main/java/org/jboss/logmanager/config/LogContextConfigurationImpl.java
+++ b/src/main/java/org/jboss/logmanager/config/LogContextConfigurationImpl.java
@@ -164,6 +164,11 @@ final class LogContextConfigurationImpl implements LogContextConfiguration {
         return new ArrayList<String>(handlers.keySet());
     }
 
+    @Override
+    public List<String> getPersistableHandlerNames() {
+        return filterPersistableNames(handlers);
+    }
+
     public FormatterConfiguration addFormatterConfiguration(final String moduleName, final String className, final String formatterName, final String... constructorProperties) {
         if (formatters.containsKey(formatterName)) {
             throw new IllegalArgumentException(String.format("Formatter \"%s\" already exists", formatterName));
@@ -193,6 +198,11 @@ final class LogContextConfigurationImpl implements LogContextConfiguration {
         return new ArrayList<String>(formatters.keySet());
     }
 
+    @Override
+    public List<String> getPersistableFormatterNames() {
+        return filterPersistableNames(formatters);
+    }
+
     public FilterConfiguration addFilterConfiguration(final String moduleName, final String className, final String filterName, final String... constructorProperties) {
         if (filters.containsKey(filterName)) {
             throw new IllegalArgumentException(String.format("Filter \"%s\" already exists", filterName));
@@ -220,6 +230,11 @@ final class LogContextConfigurationImpl implements LogContextConfiguration {
 
     public List<String> getFilterNames() {
         return new ArrayList<String>(filters.keySet());
+    }
+
+    @Override
+    public List<String> getPersistableFilterNames() {
+        return filterPersistableNames(filters);
     }
 
     public ErrorManagerConfiguration addErrorManagerConfiguration(final String moduleName, final String className, final String errorManagerName, final String... constructorProperties) {
@@ -252,6 +267,11 @@ final class LogContextConfigurationImpl implements LogContextConfiguration {
     }
 
     @Override
+    public List<String> getPersistableErrorManagerNames() {
+        return filterPersistableNames(errorManagers);
+    }
+
+    @Override
     public PojoConfiguration addPojoConfiguration(final String moduleName, final String className, final String pojoName, final String... constructorProperties) {
         if (pojos.containsKey(pojoName)) {
             throw new IllegalArgumentException(String.format("POJO \"%s\" already exists", pojoName));
@@ -281,6 +301,11 @@ final class LogContextConfigurationImpl implements LogContextConfiguration {
     @Override
     public List<String> getPojoNames() {
         return new ArrayList<String>(pojos.keySet());
+    }
+
+    @Override
+    public List<String> getPersistablePojoNames() {
+        return filterPersistableNames(pojos);
     }
 
     @Override
@@ -733,6 +758,16 @@ final class LogContextConfigurationImpl implements LogContextConfiguration {
             throw new IllegalArgumentException("Extra data after filter expression");
         }
         return result;
+    }
+
+    private static List<String> filterPersistableNames(final Map<String, ? extends PropertyConfigurable> map) {
+        final List<String> names = new ArrayList<>();
+        for (Map.Entry<String, ? extends PropertyConfigurable> entry : map.entrySet()) {
+            if (entry.getValue().isPersistable()) {
+                names.add(entry.getKey());
+            }
+        }
+        return names;
     }
 
     ObjectProducer resolveFilter(String expression) {

--- a/src/main/java/org/jboss/logmanager/config/PropertyConfigurable.java
+++ b/src/main/java/org/jboss/logmanager/config/PropertyConfigurable.java
@@ -19,6 +19,7 @@
 
 package org.jboss.logmanager.config;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -37,6 +38,19 @@ public interface PropertyConfigurable {
      * @throws IllegalArgumentException if the given value is not acceptable for this property
      */
     void setPropertyValueString(String propertyName, String value) throws IllegalArgumentException;
+
+    /**
+     * Set a property value from a string.
+     *
+     * @param propertyName the property name
+     * @param value        the property value
+     * @param persist      indicates whether or not the property should be persisted to the configuration
+     *
+     * @throws IllegalArgumentException if the given value is not acceptable for this property
+     */
+    default void setPropertyValueString(final String propertyName, final String value, final boolean persist) throws IllegalArgumentException {
+        setPropertyValueString(propertyName, value);
+    }
 
     /**
      * Get the string property value with the given name.
@@ -66,6 +80,17 @@ public interface PropertyConfigurable {
 
     /**
      * Sets the expression value for the property.
+     *
+     * @param propertyName the name of the property
+     * @param expression   the expression used to resolve the value
+     * @param persist      indicates whether or not the property should be persisted to the configuration
+     */
+    default void setPropertyValueExpression(final String propertyName, final String expression, final boolean persist) {
+        setPropertyValueExpression(propertyName, expression);
+    }
+
+    /**
+     * Sets the expression value for the property.
      * <p/>
      * This method will not parse the expression for the value and instead use the {@code value} parameter for the
      * value.
@@ -75,6 +100,22 @@ public interface PropertyConfigurable {
      * @param value        the value to use
      */
     void setPropertyValueExpression(String propertyName, String expression, String value);
+
+    /**
+     * Sets the expression value for the property.
+     * <p>
+     * This method will not parse the expression for the value and instead use the {@code value} parameter for the
+     * value.
+     * </p>
+     *
+     * @param propertyName the name of the property
+     * @param expression   the expression used to resolve the value
+     * @param value        the value to use
+     * @param persist      indicates whether or not the property should be persisted to the configuration
+     */
+    default void setPropertyValueExpression(final String propertyName, final String expression, final String value, final boolean persist) {
+        setPropertyValueExpression(propertyName, expression, value);
+    }
 
     /**
      * Determine whether the given property name is configured.
@@ -156,4 +197,34 @@ public interface PropertyConfigurable {
      * @return {@code true} if the method was removed, otherwise {@code false}
      */
     boolean removePostConfigurationMethod(String methodName);
+
+    /**
+     * Gets the configuration properties that have been set.
+     *
+     * @return the configuration properties
+     */
+    default List<ConfigurationProperty> getProperties() {
+        final List<ConfigurationProperty> result = new ArrayList<>();
+        for (String key : getPropertyNames()) {
+            result.add(new ConfigurationPropertyImpl(key, getPropertyValueExpression(key), true));
+        }
+        return result;
+    }
+
+    /**
+     * Indicates whether or not this configuration is persistable as a whole.
+     *
+     * @return {@code true} if this configuration should be persisted, owtherwise {@code false}
+     */
+    default boolean isPersistable() {
+        return true;
+    }
+
+    /**
+     * Sets whether or not this configuration should be persisted.
+     *
+     * @param persistable {@code false} if this configuration should not be persisted as a whole, otherwise {@code true}
+     */
+    default void setPersistable(final boolean persistable) {
+    }
 }

--- a/src/test/java/org/jboss/logmanager/PropertyConfiguratorTests.java
+++ b/src/test/java/org/jboss/logmanager/PropertyConfiguratorTests.java
@@ -35,6 +35,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Formatter;
+import java.util.logging.Handler;
 
 import org.jboss.logmanager.config.HandlerConfiguration;
 import org.jboss.logmanager.config.LogContextConfiguration;
@@ -319,6 +320,115 @@ public class PropertyConfiguratorTests {
 
     }
 
+    @Test
+    public void testNonPersistableProperty() throws Exception {
+        final String typeName = TestQueueHandler.class.getName();
+        final String handlerName = "testQueue";
+        final String childHandlerName = "testChild";
+
+        final LogContext logContext = LogContext.create();
+        final PropertyConfigurator configurator = new PropertyConfigurator(logContext);
+
+        final LogContextConfiguration logContextConfiguration = configurator.getLogContextConfiguration();
+
+        // Add a handler that will not persist the handler names
+        final HandlerConfiguration handlerConfiguration = logContextConfiguration.
+                addHandlerConfiguration(null, typeName, handlerName);
+        handlerConfiguration.setLevel("INFO");
+        handlerConfiguration.setHandlerNamesPersistable(false);
+        handlerConfiguration.setPropertyValueString("value", "testParentValue", true);
+
+        // Add a root logger
+        final LoggerConfiguration loggerConfiguration = logContextConfiguration.addLoggerConfiguration("");
+        loggerConfiguration.addHandlerName(handlerName);
+        loggerConfiguration.setLevel("INFO");
+
+        final HandlerConfiguration childHandlerConfiguration = logContextConfiguration
+                .addHandlerConfiguration(null, typeName, childHandlerName);
+        // Add a property that should not be persisted
+        childHandlerConfiguration.setPropertyValueString("value", "testValue", false);
+        // Add the handler which should not be persisted
+        handlerConfiguration.addHandlerName(childHandlerConfiguration.getName());
+
+        logContextConfiguration.commit();
+
+        // Since the VALUE is static it should always be set to the second configured value, however that value should
+        // not be persisted to via the PropertyConfigurator. The later will be tested below.
+        assertEquals("testValue", TestQueueHandler.VALUE);
+
+        // Reload output streams into properties
+        final Properties configProps = new Properties();
+        final ByteArrayOutputStream configOut = new ByteArrayOutputStream();
+        configurator.writeConfiguration(configOut);
+        final ByteArrayInputStream configIn = new ByteArrayInputStream(configOut.toByteArray());
+        configProps.load(new InputStreamReader(configIn, ENCODING));
+
+        // Manually create the expected properties and compare the written results
+        final Properties expectedProperties = new Properties();
+        expectedProperties.setProperty("loggers", "");
+        expectedProperties.setProperty("logger.level", "INFO");
+        expectedProperties.setProperty("logger.handlers", handlerName);
+        expectedProperties.setProperty("handlers", childHandlerName);
+        expectedProperties.setProperty("handler." + handlerName, typeName);
+        expectedProperties.setProperty("handler." + handlerName + ".level", "INFO");
+        expectedProperties.setProperty("handler." + handlerName + ".properties", "value");
+        expectedProperties.setProperty("handler." + handlerName + ".value", "testParentValue");
+        expectedProperties.setProperty("handler." + childHandlerName, typeName);
+        compare(expectedProperties, configProps);
+    }
+
+    @Test
+    public void testNonPersistableHandler() throws Exception {
+        final String typeName = TestQueueHandler.class.getName();
+        final String handlerName = "testQueue";
+        final String childHandlerName = "testChild";
+
+        final LogContext logContext = LogContext.create();
+        final PropertyConfigurator configurator = new PropertyConfigurator(logContext);
+
+        final LogContextConfiguration logContextConfiguration = configurator.getLogContextConfiguration();
+
+        // Add a handler that will not persist the handler names
+        final HandlerConfiguration handlerConfiguration = logContextConfiguration.
+                addHandlerConfiguration(null, typeName, handlerName);
+        handlerConfiguration.setLevel("INFO");
+        handlerConfiguration.setHandlerNamesPersistable(false);
+        handlerConfiguration.setPropertyValueString("value", "testParentValue", true);
+
+        // Add a root logger
+        final LoggerConfiguration loggerConfiguration = logContextConfiguration.addLoggerConfiguration("");
+        loggerConfiguration.addHandlerName(handlerName);
+        loggerConfiguration.setLevel("INFO");
+
+        final HandlerConfiguration childHandlerConfiguration = logContextConfiguration
+                .addHandlerConfiguration(null, typeName, childHandlerName);
+        // Add a property that should not be persisted
+        childHandlerConfiguration.setPropertyValueString("value", "testValue");
+        childHandlerConfiguration.setPersistable(false);
+        // Add the handler which should not be persisted
+        handlerConfiguration.addHandlerName(childHandlerConfiguration.getName());
+
+        logContextConfiguration.commit();
+
+        // Reload output streams into properties
+        final Properties configProps = new Properties();
+        final ByteArrayOutputStream configOut = new ByteArrayOutputStream();
+        configurator.writeConfiguration(configOut);
+        final ByteArrayInputStream configIn = new ByteArrayInputStream(configOut.toByteArray());
+        configProps.load(new InputStreamReader(configIn, ENCODING));
+
+        // Manually create the expected properties and compare the written results
+        final Properties expectedProperties = new Properties();
+        expectedProperties.setProperty("loggers", "");
+        expectedProperties.setProperty("logger.level", "INFO");
+        expectedProperties.setProperty("logger.handlers", handlerName);
+        expectedProperties.setProperty("handler." + handlerName, typeName);
+        expectedProperties.setProperty("handler." + handlerName + ".level", "INFO");
+        expectedProperties.setProperty("handler." + handlerName + ".properties", "value");
+        expectedProperties.setProperty("handler." + handlerName + ".value", "testParentValue");
+        compare(expectedProperties, configProps);
+    }
+
     private void compare(final Properties defaultProps, final Properties configProps) {
         final Set<String> dftNames = defaultProps.stringPropertyNames();
         final Set<String> configNames = configProps.stringPropertyNames();
@@ -472,6 +582,31 @@ public class PropertyConfiguratorTests {
             } catch (Exception ignore) {
                 // ignore
             }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class TestQueueHandler extends ExtHandler {
+
+        private static String VALUE;
+
+        public String getValue() {
+            return VALUE;
+        }
+
+        public void setValue(final String value) {
+            VALUE = value;
+        }
+
+        @Override
+        protected void doPublish(final ExtLogRecord record) {
+            final Handler[] children = getHandlers();
+            if (children != null) {
+                for (Handler child : children) {
+                    child.publish(record);
+                }
+            }
+            super.doPublish(record);
         }
     }
 }


### PR DESCRIPTION
…s for a handler configuration to not be persisted to configuration file via the PropertyConfigurator.

https://issues.jboss.org/browse/LOGMGR-188

One thing to note is there is no real guard against setting a constructor property which is a property that is not persisted. However this shouldn't really happen as the value would be needed during construction and would be considered a user error. It's possible we should do a check and guard against this.