### PR TITLE
[LOGMGR-191] Amend NullPointerException in RegexFilter.isLoggable()

### DIFF
--- a/src/main/java/org/jboss/logmanager/filters/RegexFilter.java
+++ b/src/main/java/org/jboss/logmanager/filters/RegexFilter.java
@@ -60,7 +60,13 @@ public final class RegexFilter implements Filter {
     @Override
     public boolean isLoggable(final LogRecord record) {
         if (record instanceof ExtLogRecord) {
+            if (((ExtLogRecord) record).getFormattedMessage() == null) {
+                return false;
+            }
             return pattern.matcher(((ExtLogRecord) record).getFormattedMessage()).find();
+        }
+        if (record.getMessage() == null) {
+            return false;
         }
         return pattern.matcher(record.getMessage()).find();
     }

--- a/src/test/java/org/jboss/logmanager/FilterTests.java
+++ b/src/test/java/org/jboss/logmanager/FilterTests.java
@@ -437,6 +437,23 @@ public final class FilterTests {
     }
 
     @Test
+    public void testRegexFilter4() {
+        final Filter filter = new RegexFilter("pest");
+        final AtomicBoolean ran = new AtomicBoolean();
+        final Handler handler = new CheckingHandler(ran);
+        final Logger logger = Logger.getLogger("filterTest");
+        final ExtLogRecord record = new ExtLogRecord(Level.ERROR, null, FormatStyle.MESSAGE_FORMAT, "filterTest");
+        record.setThrown(new Exception());
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        logger.setLevel(Level.INFO);
+        logger.setFilter(filter);
+        handler.setLevel(Level.INFO);
+        logger.log(record);
+        assertFalse("Handler was run", ran.get());
+    }
+
+    @Test
     public void testSubstitueFilter0() {
         final Filter filter = new SubstituteFilter(Pattern.compile("test"), "lunch", true);
         final AtomicReference<String> result = new AtomicReference<String>();


### PR DESCRIPTION
Unit test and fix.

Note, if this fix is not applied, ran.get() in the testRegexFilter4 would return 'true' because  Logger.publish() simply ignores the NullPointerException. (So it's slightly different from the scenario described in the JIRA). Anyway, RegexFilter.isLoggable() should explicitly return 'false', I think.

https://github.com/jboss-logging/jboss-logmanager/blob/master/src/main/java/org/jboss/logmanager/Logger.java#L846-L849
