### PR TITLE
[LOGMGR-133] Follow up PR to add the findCallingClasses() method for …

### DIFF
--- a/src/main/java9/org/jboss/logmanager/formatters/StackTraceFormatter.java
+++ b/src/main/java9/org/jboss/logmanager/formatters/StackTraceFormatter.java
@@ -18,7 +18,6 @@
 
 package org.jboss.logmanager.formatters;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;


### PR DESCRIPTION
…JDK 9 specific implementation. Also added a copyright and removed an unused import.

https://issues.jboss.org/browse/LOGMGR-133