### PR TITLE
[LOGMGR-191] Handle null messages in regex filters.

### DIFF
--- a/src/main/java/org/jboss/logmanager/filters/RegexFilter.java
+++ b/src/main/java/org/jboss/logmanager/filters/RegexFilter.java
@@ -59,9 +59,12 @@ public final class RegexFilter implements Filter {
      */
     @Override
     public boolean isLoggable(final LogRecord record) {
+        final String msg;
         if (record instanceof ExtLogRecord) {
-            return pattern.matcher(((ExtLogRecord) record).getFormattedMessage()).find();
+            msg = ((ExtLogRecord) record).getFormattedMessage();
+        } else {
+            msg = record.getMessage();
         }
-        return pattern.matcher(record.getMessage()).find();
+        return pattern.matcher(String.valueOf(msg)).find();
     }
 }

--- a/src/main/java/org/jboss/logmanager/filters/SubstituteFilter.java
+++ b/src/main/java/org/jboss/logmanager/filters/SubstituteFilter.java
@@ -73,12 +73,13 @@ public final class SubstituteFilter implements Filter {
      */
     @Override
     public boolean isLoggable(final LogRecord record) {
-        final Matcher matcher;
+        final String currentMsg;
         if (record instanceof ExtLogRecord) {
-            matcher = pattern.matcher(((ExtLogRecord) record).getFormattedMessage());
+            currentMsg = ((ExtLogRecord) record).getFormattedMessage();
         } else {
-            matcher = pattern.matcher(record.getMessage());
+            currentMsg = record.getMessage();
         }
+        final Matcher matcher = pattern.matcher(String.valueOf(currentMsg));
         final String msg;
         if (replaceAll) {
             msg = matcher.replaceAll(replacement);


### PR DESCRIPTION
https://issues.jboss.org/browse/LOGMGR-191

This will allow a pattern with `"null"` to be used to match `null` records.