### PR TITLE
[LOGMGR-191] Handle null messages in regex filters.

### DIFF
--- a/src/main/java/org/jboss/logmanager/filters/RegexFilter.java
+++ b/src/main/java/org/jboss/logmanager/filters/RegexFilter.java
@@ -68,6 +68,6 @@ public final class RegexFilter implements Filter {
         if (message == null) {
             message = record.getMessage();
         }
-        return pattern.matcher(message).find();
+        return pattern.matcher(String.valueOf(message)).find();
     }
 }

--- a/src/main/java/org/jboss/logmanager/filters/SubstituteFilter.java
+++ b/src/main/java/org/jboss/logmanager/filters/SubstituteFilter.java
@@ -70,7 +70,7 @@ public final class SubstituteFilter implements Filter {
      * @return {@code true} always
      */
     public boolean isLoggable(final LogRecord record) {
-        final Matcher matcher = pattern.matcher(record.getMessage());
+        final Matcher matcher = pattern.matcher(String.valueOf(record.getMessage()));
         final String msg;
         if (replaceAll) {
             msg = matcher.replaceAll(replacement);


### PR DESCRIPTION
https://issues.jboss.org/browse/LOGMGR-191

This will allow a pattern with `"null"` to be used to match `null` records.