### PR TITLE
Jbeap 14320

### DIFF
--- a/src/test/java/org/jboss/logmanager/FilterTests.java
+++ b/src/test/java/org/jboss/logmanager/FilterTests.java
@@ -437,6 +437,15 @@ public final class FilterTests {
     }
 
     @Test
+    public void regexFilterExceptionNullMessageTest(){
+        final ExtLogRecord logRecord = new ExtLogRecord(Level.ALL, null, null);
+        final Filter filter = new RegexFilter("test");
+        boolean isLoggable = filter.isLoggable(logRecord);
+        assertFalse(isLoggable);
+        assertNull(logRecord.getFormattedMessage());
+    }
+
+    @Test
     public void testSubstitueFilter0() {
         final Filter filter = new SubstituteFilter(Pattern.compile("test"), "lunch", true);
         final AtomicReference<String> result = new AtomicReference<String>();
@@ -488,6 +497,14 @@ public final class FilterTests {
         record.setParameters(new String[] {"test"});
         filter.isLoggable(record);
         assertEquals("Substitution was not correctly applied", "This is a lunches lunches", record.getFormattedMessage());
+    }
+
+    @Test
+    public void substituteFilterExceptionNullMessageTest(){
+        final ExtLogRecord logRecord = new ExtLogRecord(Level.ALL, null, null);
+        final Filter filter = new SubstituteFilter(Pattern.compile("test"), "lunch", true);
+        filter.isLoggable(logRecord);
+        assertEquals("null", logRecord.getFormattedMessage());
     }
 
 


### PR DESCRIPTION
JIRA task [https://issues.jboss.org/browse/JBEAP-14320](https://issues.jboss.org/browse/JBEAP-14320 - Amend NullPointerException in RegexFilter.isLoggable())

Description: When log message is null, RegexFilter.isLoggable() throws NullPointerException.

https://github.com/jboss-logging/jboss-logmanager/blob/master/src/main/java/org/jboss/logmanager/filters/RegexFilter.java#L63
It often results in unexpected outcomes. For example, assuming you have a filter-spec with "not(match(xxx))" to suppress some messages in your logger configuration...



