### PR TITLE
[LOGMGR-201] Allow null messages, as other handlers to, to passed to …

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/SyslogHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/SyslogHandler.java
@@ -498,10 +498,6 @@ public class SyslogHandler extends ExtHandler {
 
     @Override
     public final void doPublish(final ExtLogRecord record) {
-        // Don't log empty messages
-        if (record.getMessage() == null || record.getMessage().isEmpty()) {
-            return;
-        }
         synchronized (outputLock) {
             init();
             if (out == null) {

--- a/src/test/java/org/jboss/logmanager/handlers/SyslogHandlerTests.java
+++ b/src/test/java/org/jboss/logmanager/handlers/SyslogHandlerTests.java
@@ -182,6 +182,22 @@ public class SyslogHandlerTests {
 
     }
 
+    @Test
+    public void testNullMessage() throws Exception {
+        // Setup the handler
+        handler.setSyslogType(SyslogType.RFC5424);
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        handler.setOutputStream(out);
+
+        final Calendar cal = getCalendar();
+        // Create the record
+        handler.setHostname("test");
+        ExtLogRecord record = createRecord(cal, null);
+        final String expectedMessage = "<14>1 2012-01-09T04:39:22.000" + calculateTimeZone(cal) + " test java " + handler.getPid() + " - - " + BOM + "null";
+        handler.publish(record);
+        Assert.assertEquals(expectedMessage, createString(out));
+    }
+
     private void testMultibyteTruncation(final String part1, final String part2, final int charsToTruncate) throws Exception {
         // Setup the handler
         handler.setSyslogType(SyslogType.RFC5424);


### PR DESCRIPTION
…the SyslogHandler. A null message should be handled by the formatter, not the handler.

https://issues.jboss.org/browse/LOGMGR-201