### PR TITLE
[LOGMGR-213] Add a System.LoggerFinder which will set the java.util.l…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,13 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <!-- Optional and provided as this is only a compile-time dependency -->
+            <optional>true</optional>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>
@@ -175,4 +182,51 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>java9-tests</id>
+            <activation>
+                <jdk>[9,</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>test-compile-java9</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                                <configuration>
+                                    <release>9</release>
+                                    <buildDirectory>${project.build.directory}</buildDirectory>
+                                    <compileSourceRoots>${project.basedir}/src/test/java9</compileSourceRoots>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/core/src/main/java/org/jboss/logmanager/JBossLoggerFinder.java
+++ b/core/src/main/java/org/jboss/logmanager/JBossLoggerFinder.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+/**
+ * For Java 8 this is just an empty type. For Java 9 or greater this implements the {@code System.LoggerFinder}. It
+ * will make an attempt to set the {@code java.util.logging.manager} system property before a logger is accessed.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JBossLoggerFinder {
+}

--- a/core/src/main/java9/org/jboss/logmanager/JBossLoggerFinder.java
+++ b/core/src/main/java9/org/jboss/logmanager/JBossLoggerFinder.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JBossLoggerFinder extends System.LoggerFinder {
+    private static final Map<System.Logger.Level, java.util.logging.Level> LEVELS = new EnumMap<>(System.Logger.Level.class);
+    private static final AtomicBoolean LOGGED = new AtomicBoolean(false);
+    private static volatile boolean PROPERTY_SET = false;
+
+    static {
+        LEVELS.put(System.Logger.Level.ALL, Level.ALL);
+        LEVELS.put(System.Logger.Level.TRACE, Level.TRACE);
+        LEVELS.put(System.Logger.Level.DEBUG, Level.DEBUG);
+        LEVELS.put(System.Logger.Level.INFO, Level.INFO);
+        LEVELS.put(System.Logger.Level.WARNING, Level.WARN);
+        LEVELS.put(System.Logger.Level.ERROR, Level.ERROR);
+        LEVELS.put(System.Logger.Level.OFF, Level.OFF);
+    }
+
+    @Override
+    public System.Logger getLogger(final String name, final Module module) {
+        if (!PROPERTY_SET) {
+            synchronized (this) {
+                if (!PROPERTY_SET) {
+                    if (System.getSecurityManager() == null) {
+                        if (System.getProperty("java.util.logging.manager") == null) {
+                            System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
+                        }
+                    } else {
+                        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                            if (System.getProperty("java.util.logging.manager") == null) {
+                                System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
+                            }
+                            return null;
+                        });
+                    }
+                }
+                PROPERTY_SET = true;
+            }
+        }
+        final java.util.logging.Logger logger = java.util.logging.Logger.getLogger(name);
+        if (!(logger instanceof org.jboss.logmanager.Logger)) {
+            if (LOGGED.compareAndSet(false, true)) {
+                logger.log(Level.ERROR, "The LogManager accessed before the \"java.util.logging.manager\" system property was set to \"org.jboss.logmanager.LogManager\". Results may be unexpected.");
+            }
+        }
+        return new JBossSystemLogger(logger);
+    }
+
+    private static class JBossSystemLogger implements System.Logger {
+        private static final String LOGGER_CLASS_NAME = JBossSystemLogger.class.getName();
+        private final java.util.logging.Logger delegate;
+
+        private JBossSystemLogger(final java.util.logging.Logger delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String getName() {
+            return delegate.getName();
+        }
+
+        @Override
+        public boolean isLoggable(final Level level) {
+            return delegate.isLoggable(LEVELS.getOrDefault(level, java.util.logging.Level.INFO));
+        }
+
+        @Override
+        public void log(final Level level, final ResourceBundle bundle, final String msg, final Throwable thrown) {
+            final ExtLogRecord record = new ExtLogRecord(LEVELS.getOrDefault(level, java.util.logging.Level.INFO), msg, LOGGER_CLASS_NAME);
+            record.setThrown(thrown);
+            record.setResourceBundle(bundle);
+            delegate.log(record);
+        }
+
+        @Override
+        public void log(final Level level, final ResourceBundle bundle, final String format, final Object... params) {
+            final ExtLogRecord record = new ExtLogRecord(LEVELS.getOrDefault(level, java.util.logging.Level.INFO), format, ExtLogRecord.FormatStyle.MESSAGE_FORMAT, LOGGER_CLASS_NAME);
+            record.setParameters(params);
+            record.setResourceBundle(bundle);
+            delegate.log(record);
+        }
+    }
+}

--- a/core/src/main/resources/META-INF/services/java.lang.System$LoggerFinder
+++ b/core/src/main/resources/META-INF/services/java.lang.System$LoggerFinder
@@ -1,0 +1,20 @@
+#
+# JBoss, Home of Professional Open Source.
+#
+# Copyright 2018 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.jboss.logmanager.JBossLoggerFinder

--- a/core/src/test/java/org/jboss/logmanager/TestConfiguratorFactory.java
+++ b/core/src/test/java/org/jboss/logmanager/TestConfiguratorFactory.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import org.kohsuke.MetaInfServices;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@MetaInfServices
+public class TestConfiguratorFactory implements ConfiguratorFactory {
+    @Override
+    public LogContextConfigurator create() {
+        return new TestLogContextConfigurator(false);
+    }
+
+    @Override
+    public int priority() {
+        return 50;
+    }
+}

--- a/core/src/test/java/org/jboss/logmanager/TestLogContextConfigurator.java
+++ b/core/src/test/java/org/jboss/logmanager/TestLogContextConfigurator.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jboss.logmanager.formatters.JsonFormatter;
+import org.jboss.logmanager.handlers.FileHandler;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class TestLogContextConfigurator implements LogContextConfigurator {
+
+    public TestLogContextConfigurator() {
+        this(true);
+    }
+
+    TestLogContextConfigurator(final boolean assumedJul) {
+        if (assumedJul) {
+            configure(null);
+        }
+    }
+
+    @Override
+    public void configure(final LogContext logContext, final InputStream inputStream) {
+        configure(logContext);
+    }
+
+    private static void configure(final LogContext logContext) {
+        if (Boolean.getBoolean("org.jboss.logmanager.test.configure")) {
+            final Logger rootLogger;
+            if (logContext == null) {
+                rootLogger = Logger.getLogger("");
+            } else {
+                rootLogger = logContext.getLogger("");
+            }
+            try {
+                final String fileName = System.getProperty("test.log.file.name");
+                final FileHandler handler = new FileHandler(fileName, false);
+                handler.setAutoFlush(true);
+                handler.setFormatter(new JsonFormatter());
+                rootLogger.addHandler(handler);
+                rootLogger.setLevel(Level.INFO);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/core/src/test/java9/org/jboss/logmanager/SystemLoggerIT.java
+++ b/core/src/test/java9/org/jboss/logmanager/SystemLoggerIT.java
@@ -1,0 +1,196 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SystemLoggerIT {
+    private static final boolean WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+
+    private Path stdout;
+    private Path logFile;
+
+    @Before
+    public void setup() throws Exception {
+        stdout = Files.createTempFile("stdout", ".txt");
+        logFile = Files.createTempFile("system-logger", ".log");
+    }
+
+    @After
+    public void killProcess() throws IOException {
+        Files.deleteIfExists(stdout);
+        Files.deleteIfExists(logFile);
+    }
+
+    @Test
+    public void testSystemLoggerActivated() throws Exception {
+        final Process process = createProcess();
+        if (process.waitFor(3L, TimeUnit.SECONDS)) {
+            final int exitCode = process.exitValue();
+            final StringBuilder msg = new StringBuilder("Expected exit value 0 got ")
+                    .append(exitCode);
+            appendStdout(msg);
+            Assert.assertEquals(msg.toString(), 0, exitCode);
+        } else {
+            final Process destroyed = process.destroyForcibly();
+            final StringBuilder msg = new StringBuilder("Failed to exit process within 3 seconds. Exit Code: ")
+                    .append(destroyed.exitValue());
+            appendStdout(msg);
+            Assert.fail(msg.toString());
+        }
+
+        final JsonObject json = readLogFile(logFile);
+        final JsonArray lines = json.getJsonArray("lines");
+        Assert.assertEquals(2, lines.size());
+        // The first line should be from a SystemLogger
+        JsonObject line = lines.getJsonObject(0);
+        Assert.assertEquals("org.jboss.logmanager.JBossLoggerFinder$JBossSystemLogger", line.getString("loggerClassName"));
+        JsonObject mdc = line.getJsonObject("mdc");
+        Assert.assertEquals("org.jboss.logmanager.JBossLoggerFinder$JBossSystemLogger", mdc.getString("logger.type"));
+        Assert.assertEquals(LogManager.class.getName(), mdc.getString("java.util.logging.LogManager"));
+        Assert.assertEquals(LogManager.class.getName(), mdc.getString("java.util.logging.manager"));
+
+        // The second line should be from a JUL logger
+        line = lines.getJsonObject(1);
+        Assert.assertEquals(Logger.class.getName(), line.getString("loggerClassName"));
+        mdc = line.getJsonObject("mdc");
+        Assert.assertEquals(Logger.class.getName(), mdc.getString("logger.type"));
+        Assert.assertEquals(LogManager.class.getName(), mdc.getString("java.util.logging.LogManager"));
+        Assert.assertEquals(LogManager.class.getName(), mdc.getString("java.util.logging.manager"));
+    }
+
+    @Test
+    public void testSystemLoggerAccessedBeforeActivated() throws Exception {
+        final Process process = createProcess("-Dsystem.logger.test.jul=true",
+                "-Djava.util.logging.config.class=" + TestLogContextConfigurator.class.getName());
+        if (process.waitFor(3L, TimeUnit.SECONDS)) {
+            final int exitCode = process.exitValue();
+            final StringBuilder msg = new StringBuilder("Expected exit value 0 got ")
+                    .append(exitCode);
+            appendStdout(msg);
+            Assert.assertEquals(msg.toString(), 0, exitCode);
+        } else {
+            final Process destroyed = process.destroyForcibly();
+            final StringBuilder msg = new StringBuilder("Failed to exit process within 3 seconds. Exit Code: ")
+                    .append(destroyed.exitValue());
+            appendStdout(msg);
+            Assert.fail(msg.toString());
+        }
+
+        final JsonObject json = readLogFile(logFile);
+        final JsonArray lines = json.getJsonArray("lines");
+        Assert.assertEquals(3, lines.size());
+
+        // The first line should be an error indicating the java.util.logging.manager wasn't set before the LogManager
+        // was accessed
+        JsonObject line = lines.getJsonObject(0);
+        Assert.assertEquals("ERROR", line.getString("level"));
+        final String message = line.getString("message");
+        Assert.assertNotNull(message);
+        Assert.assertTrue(message.contains("java.util.logging.manager"));
+
+        // The second line should be from a SystemLogger
+        line = lines.getJsonObject(1);
+        Assert.assertEquals("org.jboss.logmanager.JBossLoggerFinder$JBossSystemLogger", line.getString("loggerClassName"));
+        JsonObject mdc = line.getJsonObject("mdc");
+        Assert.assertEquals("org.jboss.logmanager.JBossLoggerFinder$JBossSystemLogger", mdc.getString("logger.type"));
+        Assert.assertEquals("java.util.logging.LogManager", mdc.getString("java.util.logging.LogManager"));
+
+        // The third line should be from a JUL logger
+        line = lines.getJsonObject(2);
+        Assert.assertEquals("java.util.logging.Logger", line.getString("loggerClassName"));
+        mdc = line.getJsonObject("mdc");
+        Assert.assertEquals("java.util.logging.Logger", mdc.getString("logger.type"));
+        Assert.assertEquals("java.util.logging.LogManager", mdc.getString("java.util.logging.LogManager"));
+    }
+
+    private Process createProcess(final String... javaOpts) throws IOException {
+        final List<String> cmd = new ArrayList<>();
+        cmd.add(findJavaCommand());
+        cmd.add("-ea");
+        cmd.add("--add-modules=java.se");
+        cmd.add("-Dorg.jboss.logmanager.test.configure=true");
+        cmd.add("-Dtest.log.file.name=" + logFile.toString());
+        Collections.addAll(cmd, javaOpts);
+        cmd.add("-cp");
+        cmd.add(System.getProperty("java.class.path"));
+        cmd.add(SystemLoggerMain.class.getName());
+        return new ProcessBuilder(cmd)
+                .redirectErrorStream(true)
+                .redirectOutput(stdout.toFile())
+                .start();
+    }
+
+    private void appendStdout(final StringBuilder builder) throws IOException {
+        for (String line : Files.readAllLines(stdout)) {
+            builder.append(System.lineSeparator())
+                    .append(line);
+        }
+    }
+
+    private static JsonObject readLogFile(final Path logFile) throws IOException {
+        final JsonArrayBuilder builder = Json.createArrayBuilder();
+        try (BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                try (JsonReader jsonReader = Json.createReader(new StringReader(line))) {
+                    builder.add(jsonReader.read());
+                }
+            }
+        }
+        return Json.createObjectBuilder().add("lines", builder).build();
+    }
+
+    private static String findJavaCommand() {
+        String javaHome = System.getProperty("java.home");
+        if (javaHome != null) {
+            String exe = "java";
+            if (WINDOWS) {
+                exe = "java.exe";
+            }
+            return Paths.get(javaHome, "bin", exe).toAbsolutePath().toString();
+        }
+        return "java";
+    }
+}

--- a/core/src/test/java9/org/jboss/logmanager/SystemLoggerMain.java
+++ b/core/src/test/java9/org/jboss/logmanager/SystemLoggerMain.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SystemLoggerMain {
+
+    public static void main(final String[] args) {
+        if (Boolean.getBoolean("system.logger.test.jul")) {
+            // Access the log manager to ensure it's configured before the system property is set
+            LogManager.getLogManager();
+        }
+
+        final System.Logger.Level level = System.Logger.Level.valueOf(System.getProperty("system.logger.test.level", "INFO"));
+        final String msgId = System.getProperty("system.logger.test.msg.id");
+        final String msg = String.format("Test message from %s id %s", SystemLoggerMain.class.getName(), msgId);
+        final System.Logger systemLogger = System.getLogger(SystemLoggerMain.class.getName());
+        MDC.put("logger.type", systemLogger.getClass().getName());
+        MDC.put("java.util.logging.LogManager", LogManager.getLogManager().getClass().getName());
+        MDC.put("java.util.logging.manager", System.getProperty("java.util.logging.manager"));
+        systemLogger.log(level, msg);
+
+        final Logger logger = Logger.getLogger(SystemLoggerMain.class.getName());
+        MDC.put("logger.type", logger.getClass().getName());
+        MDC.put("java.util.logging.LogManager", LogManager.getLogManager().getClass().getName());
+        MDC.put("java.util.logging.manager", System.getProperty("java.util.logging.manager"));
+        logger.info(msg);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,15 @@
         <org.jboss.test.port>4560</org.jboss.test.port>
         <org.jboss.test.alt.port>14560</org.jboss.test.alt.port>
 
+        <skipTests>false</skipTests>
+        <skipITs>${skipTests}</skipITs>
+        <skipUTs>${skipTests}</skipUTs>
+
+        <!-- Please note this version override is only done to support the testCompile use-case for Java 9+ tests. The
+             testCompile does not seem to include test dependencies on the class path in 3.8.0-jboss-1 for some reason.
+        -->
+        <version.compiler.plugin>3.7.0-jboss-1</version.compiler.plugin>
+
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
@@ -148,6 +157,34 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <configuration>
+                        <skipTests>${skipTests}</skipTests>
+                        <skipITs>${skipITs}</skipITs>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <skipTests>${skipUTs}</skipTests>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
     <profiles>
         <!-- This profile is required to add the tools.jar to the class path for Java 8 for byteman -->


### PR DESCRIPTION
…ogging.manager system property if not already set. This allows the JBoss Log Manager to be used if the system property was not set before a System.Logger is requested.

https://issues.jboss.org/browse/LOGMGR-213