### PR TITLE
[LOGMGR-213] Add a System.LoggerFinder which will set the java.util.l…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,9 @@
                                     <additionalClasspathElements>
                                         <additionalClasspathElement>${java8.home}/lib/tools.jar</additionalClasspathElement>
                                     </additionalClasspathElements>
+                                    <excludes>
+                                        <exclude>org/jboss/logmanager/SystemLoggerTests.java</exclude>
+                                    </excludes>
                                 </configuration>
                             </execution>
                         </executions>
@@ -197,6 +200,18 @@
                             <additionalClasspathElements>
                                 <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
                             </additionalClasspathElements>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile-java9</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <release>9</release>
+                            <buildDirectory>${project.build.directory}</buildDirectory>
+                            <compileSourceRoots>${project.basedir}/src/test/java9</compileSourceRoots>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/org/jboss/logmanager/JBossLoggerFinder.java
+++ b/src/main/java/org/jboss/logmanager/JBossLoggerFinder.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+/**
+ * For Java 8 this is just an empty type. For Java 9 or greater this implements the {@code System.LoggerFinder}. It
+ * will make an attempt to set the {@code java.util.logging.manager} system property before a logger is accessed.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JBossLoggerFinder {
+}

--- a/src/main/java9/org/jboss/logmanager/JBossLoggerFinder.java
+++ b/src/main/java9/org/jboss/logmanager/JBossLoggerFinder.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JBossLoggerFinder extends System.LoggerFinder {
+    private static final Map<System.Logger.Level, java.util.logging.Level> LEVELS = new EnumMap<>(System.Logger.Level.class);
+    private static final AtomicBoolean LOGGED = new AtomicBoolean(false);
+    private static volatile boolean PROPERTY_SET = false;
+
+    static {
+        LEVELS.put(System.Logger.Level.ALL, Level.ALL);
+        LEVELS.put(System.Logger.Level.TRACE, Level.TRACE);
+        LEVELS.put(System.Logger.Level.DEBUG, Level.DEBUG);
+        LEVELS.put(System.Logger.Level.INFO, Level.INFO);
+        LEVELS.put(System.Logger.Level.WARNING, Level.WARN);
+        LEVELS.put(System.Logger.Level.ERROR, Level.ERROR);
+        LEVELS.put(System.Logger.Level.OFF, Level.OFF);
+    }
+
+    @Override
+    public System.Logger getLogger(final String name, final Module module) {
+        if (!PROPERTY_SET) {
+            synchronized (this) {
+                if (!PROPERTY_SET) {
+                    if (System.getSecurityManager() == null) {
+                        if (System.getProperty("java.util.logging.manager") == null) {
+                            System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
+                        }
+                    } else {
+                        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                            if (System.getProperty("java.util.logging.manager") == null) {
+                                System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
+                            }
+                            return null;
+                        });
+                    }
+                }
+                PROPERTY_SET = true;
+            }
+        }
+        final java.util.logging.Logger logger = java.util.logging.Logger.getLogger(name);
+        if (!(logger instanceof org.jboss.logmanager.Logger)) {
+            if (LOGGED.compareAndSet(false, true)) {
+                logger.log(Level.ERROR, "The LogManager accessed before the \"java.util.logging.manager\" system property was set to \"org.jboss.logmanager.LogManager\". Results may be unexpected.");
+            }
+        }
+        return new JBossSystemLogger(logger);
+    }
+
+    private static class JBossSystemLogger implements System.Logger {
+        private static final String LOGGER_CLASS_NAME = JBossSystemLogger.class.getName();
+        private final java.util.logging.Logger delegate;
+
+        private JBossSystemLogger(final java.util.logging.Logger delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String getName() {
+            return delegate.getName();
+        }
+
+        @Override
+        public boolean isLoggable(final Level level) {
+            return delegate.isLoggable(LEVELS.getOrDefault(level, java.util.logging.Level.INFO));
+        }
+
+        @Override
+        public void log(final Level level, final ResourceBundle bundle, final String msg, final Throwable thrown) {
+            final ExtLogRecord record = new ExtLogRecord(LEVELS.getOrDefault(level, java.util.logging.Level.INFO), msg, LOGGER_CLASS_NAME);
+            record.setThrown(thrown);
+            record.setResourceBundle(bundle);
+            delegate.log(record);
+        }
+
+        @Override
+        public void log(final Level level, final ResourceBundle bundle, final String format, final Object... params) {
+            final ExtLogRecord record = new ExtLogRecord(LEVELS.getOrDefault(level, java.util.logging.Level.INFO), format, ExtLogRecord.FormatStyle.MESSAGE_FORMAT, LOGGER_CLASS_NAME);
+            record.setParameters(params);
+            record.setResourceBundle(bundle);
+            delegate.log(record);
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/java.lang.System$LoggerFinder
+++ b/src/main/resources/META-INF/services/java.lang.System$LoggerFinder
@@ -1,0 +1,20 @@
+#
+# JBoss, Home of Professional Open Source.
+#
+# Copyright 2018 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.jboss.logmanager.JBossLoggerFinder

--- a/src/test/java9/org/jboss/logmanager/JulLoggingConfigurator.java
+++ b/src/test/java9/org/jboss/logmanager/JulLoggingConfigurator.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.io.FileNotFoundException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jboss.logmanager.formatters.JsonFormatter;
+import org.jboss.logmanager.handlers.FileHandler;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JulLoggingConfigurator {
+
+    public JulLoggingConfigurator() throws FileNotFoundException {
+        final Logger rootLogger = Logger.getLogger("");
+        final String fileName = System.getProperty("test.log.file.name");
+        final FileHandler handler = new FileHandler(fileName, false);
+        handler.setAutoFlush(true);
+        handler.setFormatter(new JsonFormatter());
+        rootLogger.addHandler(handler);
+        rootLogger.setLevel(Level.INFO);
+    }
+}

--- a/src/test/java9/org/jboss/logmanager/SystemLoggerMain.java
+++ b/src/test/java9/org/jboss/logmanager/SystemLoggerMain.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SystemLoggerMain {
+
+    public static void main(final String[] args) {
+        if (Boolean.getBoolean("system.logger.test.jul")) {
+            // Access the log manager to ensure it's configured before the system property is set
+            LogManager.getLogManager();
+        }
+
+        final System.Logger.Level level = System.Logger.Level.valueOf(System.getProperty("system.logger.test.level", "INFO"));
+        final String msgId = System.getProperty("system.logger.test.msg.id");
+        final String msg = String.format("Test message from %s id %s", SystemLoggerMain.class.getName(), msgId);
+        final System.Logger systemLogger = System.getLogger(SystemLoggerMain.class.getName());
+        MDC.put("logger.type", systemLogger.getClass().getName());
+        MDC.put("java.util.logging.LogManager", LogManager.getLogManager().getClass().getName());
+        MDC.put("java.util.logging.manager", System.getProperty("java.util.logging.manager"));
+        systemLogger.log(level, msg);
+
+        final Logger logger = Logger.getLogger(SystemLoggerMain.class.getName());
+        MDC.put("logger.type", logger.getClass().getName());
+        MDC.put("java.util.logging.LogManager", LogManager.getLogManager().getClass().getName());
+        MDC.put("java.util.logging.manager", System.getProperty("java.util.logging.manager"));
+        logger.info(msg);
+    }
+}

--- a/src/test/java9/org/jboss/logmanager/SystemLoggerTests.java
+++ b/src/test/java9/org/jboss/logmanager/SystemLoggerTests.java
@@ -1,0 +1,223 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.jboss.logmanager.formatters.JsonFormatter;
+import org.jboss.logmanager.handlers.FileHandler;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SystemLoggerTests {
+    private static final boolean WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+
+    private Path stdout;
+    private Path configFile;
+    private Path logFile;
+
+    @Before
+    public void setup() throws Exception {
+        stdout = Files.createTempFile("stdout", ".txt");
+        logFile = Files.createTempFile("system-logger", ".log");
+        configFile = Files.createTempFile("logging", ".properties");
+    }
+
+    @After
+    public void killProcess() throws IOException {
+        Files.deleteIfExists(stdout);
+        Files.deleteIfExists(logFile);
+        Files.deleteIfExists(configFile);
+    }
+
+    @Test
+    public void testSystemLoggerActivated() throws Exception {
+        createJBossLoggingConfig();
+        final Process process = createProcess("-Dlogging.configuration=" + configFile.toUri().toURL());
+        if (process.waitFor(3L, TimeUnit.SECONDS)) {
+            final int exitCode = process.exitValue();
+            final StringBuilder msg = new StringBuilder("Expected exit value 0 got ")
+                    .append(exitCode);
+            appendStdout(msg);
+            Assert.assertEquals(msg.toString(), 0, exitCode);
+        } else {
+            final Process destroyed = process.destroyForcibly();
+            final StringBuilder msg = new StringBuilder("Failed to exit process within 3 seconds. Exit Code: ")
+                    .append(destroyed.exitValue());
+            appendStdout(msg);
+            Assert.fail(msg.toString());
+        }
+
+        final JsonObject json = readLogFile(logFile);
+        final JsonArray lines = json.getJsonArray("lines");
+        Assert.assertEquals(2, lines.size());
+        // The first line should be from a SystemLogger
+        JsonObject line = lines.getJsonObject(0);
+        Assert.assertEquals("org.jboss.logmanager.JBossLoggerFinder$JBossSystemLogger", line.getString("loggerClassName"));
+        JsonObject mdc = line.getJsonObject("mdc");
+        Assert.assertEquals("org.jboss.logmanager.JBossLoggerFinder$JBossSystemLogger", mdc.getString("logger.type"));
+        Assert.assertEquals(LogManager.class.getName(), mdc.getString("java.util.logging.LogManager"));
+        Assert.assertEquals(LogManager.class.getName(), mdc.getString("java.util.logging.manager"));
+
+        // The second line should be from a JUL logger
+        line = lines.getJsonObject(1);
+        Assert.assertEquals(Logger.class.getName(), line.getString("loggerClassName"));
+        mdc = line.getJsonObject("mdc");
+        Assert.assertEquals(Logger.class.getName(), mdc.getString("logger.type"));
+        Assert.assertEquals(LogManager.class.getName(), mdc.getString("java.util.logging.LogManager"));
+        Assert.assertEquals(LogManager.class.getName(), mdc.getString("java.util.logging.manager"));
+    }
+
+    @Test
+    public void testSystemLoggerAccessedBeforeActivated() throws Exception {
+        final Process process = createProcess("-Dsystem.logger.test.jul=true", "-Dtest.log.file.name=" + logFile.toString(),
+                "-Djava.util.logging.config.class=" + JulLoggingConfigurator.class.getName());
+        if (process.waitFor(3L, TimeUnit.SECONDS)) {
+            final int exitCode = process.exitValue();
+            final StringBuilder msg = new StringBuilder("Expected exit value 0 got ")
+                    .append(exitCode);
+            appendStdout(msg);
+            Assert.assertEquals(msg.toString(), 0, exitCode);
+        } else {
+            final Process destroyed = process.destroyForcibly();
+            final StringBuilder msg = new StringBuilder("Failed to exit process within 3 seconds. Exit Code: ")
+                    .append(destroyed.exitValue());
+            appendStdout(msg);
+            Assert.fail(msg.toString());
+        }
+
+        final JsonObject json = readLogFile(logFile);
+        final JsonArray lines = json.getJsonArray("lines");
+        Assert.assertEquals(3, lines.size());
+
+        // The first line should be an error indicating the java.util.logging.manager wasn't set before the LogManager
+        // was accessed
+        JsonObject line = lines.getJsonObject(0);
+        Assert.assertEquals("ERROR", line.getString("level"));
+        final String message = line.getString("message");
+        Assert.assertNotNull(message);
+        Assert.assertTrue(message.contains("java.util.logging.manager"));
+
+        // The second line should be from a SystemLogger
+        line = lines.getJsonObject(1);
+        Assert.assertEquals("org.jboss.logmanager.JBossLoggerFinder$JBossSystemLogger", line.getString("loggerClassName"));
+        JsonObject mdc = line.getJsonObject("mdc");
+        Assert.assertEquals("org.jboss.logmanager.JBossLoggerFinder$JBossSystemLogger", mdc.getString("logger.type"));
+        Assert.assertEquals("java.util.logging.LogManager", mdc.getString("java.util.logging.LogManager"));
+
+        // The third line should be from a JUL logger
+        line = lines.getJsonObject(2);
+        Assert.assertEquals("java.util.logging.Logger", line.getString("loggerClassName"));
+        mdc = line.getJsonObject("mdc");
+        Assert.assertEquals("java.util.logging.Logger", mdc.getString("logger.type"));
+        Assert.assertEquals("java.util.logging.LogManager", mdc.getString("java.util.logging.LogManager"));
+    }
+
+    private Process createProcess(final String... javaOpts) throws IOException {
+        final List<String> cmd = new ArrayList<>();
+        cmd.add(findJavaCommand());
+        cmd.add("-ea");
+        cmd.add("--add-modules=java.se");
+        Collections.addAll(cmd, javaOpts);
+        cmd.add("-cp");
+        cmd.add(System.getProperty("java.class.path"));
+        cmd.add(SystemLoggerMain.class.getName());
+        return new ProcessBuilder(cmd)
+                .redirectErrorStream(true)
+                .redirectOutput(stdout.toFile())
+                .start();
+    }
+
+    private void createJBossLoggingConfig() throws IOException {
+        final Properties properties = new Properties();
+
+        properties.setProperty("logger.level", "INFO");
+        properties.setProperty("logger.handlers", "FILE");
+
+        properties.setProperty("handler.FILE", FileHandler.class.getName());
+        properties.setProperty("handler.FILE.formatter", "JSON");
+        properties.setProperty("handler.FILE.level", "INFO");
+        properties.setProperty("handler.FILE.properties", "autoFlush,append,fileName");
+        properties.setProperty("handler.FILE.constructorProperties", "fileName,append");
+        properties.setProperty("handler.FILE.append", "false");
+        properties.setProperty("handler.FILE.fileName", logFile.toString());
+
+        properties.setProperty("formatter.JSON", JsonFormatter.class.getName());
+
+        try (BufferedWriter writer = Files.newBufferedWriter(configFile, StandardCharsets.UTF_8)) {
+            properties.store(writer, "Test logging properties");
+        }
+    }
+
+    private void appendStdout(final StringBuilder builder) throws IOException {
+        for (String line : Files.readAllLines(stdout)) {
+            builder.append(System.lineSeparator())
+                    .append(line);
+        }
+    }
+
+    private static JsonObject readLogFile(final Path logFile) throws IOException {
+        final JsonArrayBuilder builder = Json.createArrayBuilder();
+        try (BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                try (JsonReader jsonReader = Json.createReader(new StringReader(line))) {
+                    builder.add(jsonReader.read());
+                }
+            }
+        }
+        return Json.createObjectBuilder().add("lines", builder).build();
+    }
+
+    private static String findJavaCommand() {
+        String javaHome = System.getProperty("java.home");
+        if (javaHome != null) {
+            String exe = "java";
+            if (WINDOWS) {
+                exe = "java.exe";
+            }
+            return Paths.get(javaHome, "bin", exe).toAbsolutePath().toString();
+        }
+        return "java";
+    }
+}


### PR DESCRIPTION
…ogging.manager system property if not already set. This allows the JBoss Log Manager to be used if the system property was not set before a System.Logger is requested.

https://issues.jboss.org/browse/LOGMGR-213