### PR TITLE
[LOGMGR-235] Unused code removal, Map.Entry usage, static inner classes

### DIFF
--- a/ext/src/main/java/org/jboss/logmanager/ext/formatters/JsonFormatter.java
+++ b/ext/src/main/java/org/jboss/logmanager/ext/formatters/JsonFormatter.java
@@ -123,7 +123,7 @@ public class JsonFormatter extends StructuredFormatter {
         return new FormatterJsonGenerator(factory.createGenerator(writer));
     }
 
-    private class FormatterJsonGenerator implements Generator {
+    private static class FormatterJsonGenerator implements Generator {
         private final JsonGenerator generator;
 
         private FormatterJsonGenerator(final JsonGenerator generator) {

--- a/ext/src/main/java/org/jboss/logmanager/ext/formatters/StructuredFormatter.java
+++ b/ext/src/main/java/org/jboss/logmanager/ext/formatters/StructuredFormatter.java
@@ -546,10 +546,6 @@ public abstract class StructuredFormatter extends ExtFormatter {
         return value != null && !value.isEmpty();
     }
 
-    private static boolean isNotNullOrEmpty(final Collection<?> value) {
-        return value != null && !value.isEmpty();
-    }
-
     /**
      * A generator used to create the structured output.
      */
@@ -634,8 +630,8 @@ public abstract class StructuredFormatter extends ExtFormatter {
          * @throws Exception if an error occurs while adding the data
          */
         default Generator addMetaData(final Map<String, String> metaData) throws Exception {
-            for (String key : metaData.keySet()) {
-                add(key, metaData.get(key));
+            for (Map.Entry<String, String> entry : metaData.entrySet()) {
+                add(entry.getKey(), entry.getValue());
             }
             return this;
         }

--- a/ext/src/main/java/org/jboss/logmanager/ext/formatters/XmlFormatter.java
+++ b/ext/src/main/java/org/jboss/logmanager/ext/formatters/XmlFormatter.java
@@ -212,12 +212,11 @@ public class XmlFormatter extends StructuredFormatter {
 
         @Override
         public Generator addMetaData(final Map<String, String> metaData) throws Exception {
-            for (String key : metaData.keySet()) {
+            for (Map.Entry<String, String> entry : metaData.entrySet()) {
                 writeStart("metaData");
-                xmlWriter.writeAttribute("key", key);
-                final String value = metaData.get(key);
-                if (value != null) {
-                    xmlWriter.writeCharacters(metaData.get(key));
+                xmlWriter.writeAttribute("key", entry.getKey());
+                if (entry.getValue() != null) {
+                    xmlWriter.writeCharacters(metaData.get(entry.getValue()));
                 }
                 writeEnd();
             }

--- a/ext/src/test/java/org/jboss/logmanager/ext/MapTestUtils.java
+++ b/ext/src/test/java/org/jboss/logmanager/ext/MapTestUtils.java
@@ -45,12 +45,11 @@ public class MapTestUtils {
         Assert.assertTrue(failureMessage, m2.keySet().containsAll(m1.keySet()));
 
         // At this point we know that all the keys match
-        for (K key : m1.keySet()) {
-            final V value1 = m1.get(key);
-            final V value2 = m2.get(key);
+        for (Map.Entry<K, V> entry1 : m1.entrySet()) {
+            final V value2 = m2.get(entry1.getKey());
             Assert.assertEquals(
-                    String.format("Value %s from the first map does not match value %s from the second map with key %s.", value1, value2, key),
-                    value1, value2);
+                    String.format("Value %s from the first map does not match value %s from the second map with key %s.", entry1.getValue(), value2, entry1.getKey()),
+                    entry1.getValue(), value2);
         }
     }
 

--- a/ext/src/test/java/org/jboss/logmanager/ext/handlers/PeriodicSizeRotatingFileHandlerTests.java
+++ b/ext/src/test/java/org/jboss/logmanager/ext/handlers/PeriodicSizeRotatingFileHandlerTests.java
@@ -392,7 +392,7 @@ public class PeriodicSizeRotatingFileHandlerTests extends AbstractHandlerTest {
         return (supportedPeriods.indexOf(period1) - supportedPeriods.indexOf(period2)) == 1;
     }
 
-    private class ErrorCreator {
+    private static final class ErrorCreator {
         private int handlerPeriod, logMessagePeriod;
         private boolean testSize;
 


### PR DESCRIPTION
Unused code removal - private method

Map.Entry usage is more efficient than iterating through keySet() & calling map.get(key)

static inner classes to avoid reference to the owner object

https://issues.jboss.org/browse/LOGMGR-235