### PR TITLE
[LOGMGR-218] Follows up on the previous commit which could potentiall…

### DIFF
--- a/src/main/java/org/jboss/logmanager/JDKSpecific.java
+++ b/src/main/java/org/jboss/logmanager/JDKSpecific.java
@@ -24,8 +24,6 @@ import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.jboss.modules.Module;
 import org.jboss.modules.Version;
@@ -34,11 +32,11 @@ import org.jboss.modules.Version;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 final class JDKSpecific {
-    private JDKSpecific() {}
+    private JDKSpecific() {
+    }
 
     private static final Gateway GATEWAY;
     private static final boolean JBOSS_MODULES;
-    private static final boolean MODULAR_JVM;
 
     static {
         GATEWAY = AccessController.doPrivileged(new PrivilegedAction<Gateway>() {
@@ -50,25 +48,9 @@ final class JDKSpecific {
         try {
             Module.getStartTime();
             jbossModules = true;
-        } catch (Throwable ignored) {}
-        JBOSS_MODULES = jbossModules;
-
-        // Get the current Java version and determine, by JVM version level, if this is a modular JDK
-        final String value = AccessController.doPrivileged(new PrivilegedAction<String>() {
-            @Override
-            public String run() {
-                return System.getProperty("java.specification.version");
-            }
-        });
-        // Shouldn't happen, but we'll assume we're not a modular environment
-        boolean modularJvm = false;
-        if (value != null) {
-            final Matcher matcher = Pattern.compile("^(?:1\\.)?(\\d+)$").matcher(value);
-            if (matcher.find()) {
-                modularJvm = Integer.parseInt(matcher.group(1)) >= 9;
-            }
+        } catch (Throwable ignored) {
         }
-        MODULAR_JVM = modularJvm;
+        JBOSS_MODULES = jbossModules;
     }
 
     static final class Gateway extends SecurityManager {
@@ -77,21 +59,10 @@ final class JDKSpecific {
         }
     }
 
-    /**
-     * Determines whether or not this is a modular JVM. The version of the {@code java.specification.version} is checked
-     * to determine if the version is greater than or equal to 9. This is required to disable specific features/hacks
-     * for older JVM's when the log manager is loaded on the boot class path which doesn't support multi-release JAR's.
-     *
-     * @return {@code true} if determined to be a modular JVM, otherwise {@code false}
-     */
-    static boolean isModularJvm() {
-        return MODULAR_JVM;
-    }
-
     static Class<?> findCallingClass(Set<ClassLoader> rejectClassLoaders) {
         for (Class<?> caller : GATEWAY.getClassContext()) {
             final ClassLoader classLoader = caller.getClassLoader();
-            if (classLoader != null && ! rejectClassLoaders.contains(classLoader)) {
+            if (classLoader != null && !rejectClassLoaders.contains(classLoader)) {
                 return caller;
             }
         }
@@ -102,7 +73,7 @@ final class JDKSpecific {
         final Collection<Class<?>> result = new LinkedHashSet<>();
         for (Class<?> caller : GATEWAY.getClassContext()) {
             final ClassLoader classLoader = caller.getClassLoader();
-            if (classLoader != null && ! rejectClassLoaders.contains(classLoader)) {
+            if (classLoader != null && !rejectClassLoaders.contains(classLoader)) {
                 result.add(caller);
             }
         }
@@ -118,7 +89,7 @@ final class JDKSpecific {
         Class<?> clazz = classes[i++];
         StackTraceElement element = stackTrace[j++];
         boolean found = false;
-        for (;;) {
+        for (; ; ) {
             if (clazz.getName().equals(element.getClassName())) {
                 if (clazz.getName().equals(loggerClassName)) {
                     // next entry could be the one we want!
@@ -139,13 +110,13 @@ final class JDKSpecific {
                     logRecord.setUnknownCaller();
                     return;
                 }
-                element = stackTrace[j ++];
+                element = stackTrace[j++];
             }
             if (i == classes.length) {
                 logRecord.setUnknownCaller();
                 return;
             }
-            clazz = classes[i ++];
+            clazz = classes[i++];
         }
     }
 

--- a/src/main/java/org/jboss/logmanager/Jvm.java
+++ b/src/main/java/org/jboss/logmanager/Jvm.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This is required to be separate from the {@link JDKSpecific} helper. It's specifically required for WildFly embedded
+ * as the {@link JDKSpecific} initializes JBoss Modules which could cause issues if it's initialized too early. This
+ * avoids the early initialization.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+final class Jvm {
+    private static final boolean MODULAR_JVM;
+
+    static {
+
+        // Get the current Java version and determine, by JVM version level, if this is a modular JDK
+        final String value = AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return System.getProperty("java.specification.version");
+            }
+        });
+        // Shouldn't happen, but we'll assume we're not a modular environment
+        boolean modularJvm = false;
+        if (value != null) {
+            final Matcher matcher = Pattern.compile("^(?:1\\.)?(\\d+)$").matcher(value);
+            if (matcher.find()) {
+                modularJvm = Integer.parseInt(matcher.group(1)) >= 9;
+            }
+        }
+        MODULAR_JVM = modularJvm;
+    }
+
+    /**
+     * Determines whether or not this is a modular JVM. The version of the {@code java.specification.version} is checked
+     * to determine if the version is greater than or equal to 9. This is required to disable specific features/hacks
+     * for older JVM's when the log manager is loaded on the boot class path which doesn't support multi-release JAR's.
+     *
+     * @return {@code true} if determined to be a modular JVM, otherwise {@code false}
+     */
+    static boolean isModular() {
+        return MODULAR_JVM;
+    }
+}

--- a/src/main/java/org/jboss/logmanager/LogLevelInitTask.java
+++ b/src/main/java/org/jboss/logmanager/LogLevelInitTask.java
@@ -41,7 +41,7 @@ class LogLevelInitTask implements PrivilegedAction<Void> {
     public Void run() {
         // If this is a modular JVM ignore the level hack. The check here is required when the log manager is added to
         // the boot class path. The boot class path does not support multi-release JAR's.
-        if (JDKSpecific.isModularJvm()) {
+        if (Jvm.isModular()) {
             return null;
         }
         /* This mysterious-looking hack is designed to trick JDK logging into not leaking classloaders and

--- a/src/main/java9/org/jboss/logmanager/JDKSpecific.java
+++ b/src/main/java9/org/jboss/logmanager/JDKSpecific.java
@@ -55,15 +55,6 @@ final class JDKSpecific {
         JBOSS_MODULES = jbossModules;
     }
 
-    /**
-     * Always returns {@code true}.
-     *
-     * @return {@code true}
-     */
-    static boolean isModularJvm() {
-        return true;
-    }
-
     static Class<?> findCallingClass(Set<ClassLoader> rejectClassLoaders) {
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {

--- a/src/main/java9/org/jboss/logmanager/Jvm.java
+++ b/src/main/java9/org/jboss/logmanager/Jvm.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+final class Jvm {
+
+    /**
+     * Always returns {@code true}.
+     *
+     * @return {@code true}
+     */
+    static boolean isModular() {
+        return true;
+    }
+}


### PR DESCRIPTION
…y initialize JBoss Modules too early for some use cases. One specific use case is WildFly embedded.

A revert may have been cleaner, however given a time crunch this was easier.

https://issues.jboss.org/browse/LOGMGR-218