### PR TITLE
[LOGMGR-255] If append is set to true for a rotating file which is al…

### DIFF
--- a/ext/src/main/java/org/jboss/logmanager/ext/handlers/SuffixRotator.java
+++ b/ext/src/main/java/org/jboss/logmanager/ext/handlers/SuffixRotator.java
@@ -155,6 +155,8 @@ class SuffixRotator {
         if (compressionType == CompressionType.GZIP) {
             try {
                 archiveGzip(source, target);
+                // Delete the file after it's archived to behave like a file move or rename
+                Files.delete(source);
             } catch (Exception e) {
                 errorManager.error(String.format("Failed to compress %s to %s. Compressed file may be left on the " +
                         "filesystem corrupted.", source, target), e, ErrorManager.WRITE_FAILURE);
@@ -162,6 +164,8 @@ class SuffixRotator {
         } else if (compressionType == CompressionType.ZIP) {
             try {
                 archiveZip(source, target);
+                // Delete the file after it's archived to behave like a file move or rename
+                Files.delete(source);
             } catch (Exception e) {
                 errorManager.error(String.format("Failed to compress %s to %s. Compressed file may be left on the " +
                         "filesystem corrupted.", source, target), e, ErrorManager.WRITE_FAILURE);

--- a/ext/src/test/java/org/jboss/logmanager/ext/handlers/PeriodicRotatingFileHandlerTests.java
+++ b/ext/src/test/java/org/jboss/logmanager/ext/handlers/PeriodicRotatingFileHandlerTests.java
@@ -57,6 +57,8 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
         // Create the handler
         handler = new PeriodicRotatingFileHandler(logFile.toFile(), rotateFormatter.toPattern(), false);
         handler.setFormatter(FORMATTER);
+        // Set append to true to ensure the rotated file is overwritten
+        handler.setAppend(true);
     }
 
     @After
@@ -108,6 +110,8 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         final int currentDay = cal.get(Calendar.DAY_OF_MONTH);
         final int nextDay = currentDay + 1;
+        // Set to false for this specific test
+        handler.setAppend(false);
 
         final String currentDate = sdf.format(cal.getTime());
 

--- a/ext/src/test/java/org/jboss/logmanager/ext/handlers/PeriodicSizeRotatingFileHandlerTests.java
+++ b/ext/src/test/java/org/jboss/logmanager/ext/handlers/PeriodicSizeRotatingFileHandlerTests.java
@@ -248,6 +248,8 @@ public class PeriodicSizeRotatingFileHandlerTests extends AbstractHandlerTest {
         handler.setRotateOnBoot(rotateOnBoot);
         handler.setFile(logFile);
         handler.setSuffix((dateSuffix == null ? "" : dateSuffix) + archiveSuffix);
+        // Set append to true to ensure the rotated file is overwritten
+        handler.setAppend(true);
 
         // Allow a few rotates
         for (int i = 0; i < 100; i++) {

--- a/ext/src/test/java/org/jboss/logmanager/ext/handlers/SizeRotatingFileHandlerTests.java
+++ b/ext/src/test/java/org/jboss/logmanager/ext/handlers/SizeRotatingFileHandlerTests.java
@@ -211,6 +211,8 @@ public class SizeRotatingFileHandlerTests extends AbstractHandlerTest {
         handler.setRotateOnBoot(rotateOnBoot);
         handler.setFile(logFile);
         handler.setSuffix(archiveSuffix);
+        // Set append to true to ensure the rotated file is overwritten
+        handler.setAppend(true);
 
         // Allow a few rotates
         for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
…so set to be archived delete the file after it's been archived. This ensures the base file does not continue to be appended to after it's been rotated.

https://issues.jboss.org/browse/LOGMGR-255