### PR TITLE
Fix for LOGMGR-139

### DIFF
--- a/ext/src/test/java/org/jboss/logmanager/ext/handlers/PeriodicRotatingFileHandlerTests.java
+++ b/ext/src/test/java/org/jboss/logmanager/ext/handlers/PeriodicRotatingFileHandlerTests.java
@@ -19,18 +19,6 @@
 
 package org.jboss.logmanager.ext.handlers;
 
-import java.io.BufferedWriter;
-import java.io.FileNotFoundException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.text.SimpleDateFormat;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Calendar;
-import java.util.List;
-import java.util.logging.ErrorManager;
-
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.jboss.logmanager.ExtLogRecord;
@@ -40,6 +28,25 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.logging.ErrorManager;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -64,9 +71,24 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
     }
 
     @After
-    public void closeHandler() {
+    public void closeHandler() throws IOException {
         handler.close();
         handler = null;
+        Files.list(BASE_LOG_DIR.toPath()).forEach(p -> {
+            System.out.println("deleting file " + p);
+            try {
+                File f = p.toFile();
+                if (!f.isDirectory()) {
+                    Files.delete(p);
+                } else {
+                    Files.list(f.toPath()).forEach(p1 -> p1.toFile().delete());
+                    Files.delete(p);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+        Assert.assertEquals(0, Files.list(BASE_LOG_DIR.toPath()).count());
     }
 
     @Test
@@ -146,6 +168,262 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
         Assert.assertTrue("The rotated file '" + rotatedFile.toString() + "' exists and should not", Files.notExists(rotatedFile));
     }
 
+    @Test
+    public void testPruneBasic() throws Exception {
+
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+
+        String currentDate = sdf.format(cal.getTime());
+        handler.setSuffix(".YYYY-MM-dd");
+
+        createLogRecords(10, cal, currentDate, sdf);
+
+        handler.setPruneSize(50L);
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+
+        cal.add(Calendar.DAY_OF_MONTH, -1);
+
+        List<Path> files = Files.list(BASE_LOG_DIR.toPath()).collect(Collectors.toList());
+        Assert.assertEquals(2, files.size());
+        Assert.assertEquals("periodic-rotating-file-handler.log", files.get(0).getFileName().toString());
+        Assert.assertEquals("periodic-rotating-file-handler.log." + sdf.format(cal.getTime()), files.get(1).getFileName().toString());
+
+    }
+
+    @Test(timeout = 5000L)
+    public void testPruneLarge() throws Exception {
+
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+
+        String currentDate = sdf.format(cal.getTime());
+        handler.setSuffix(".YYYY-MM-dd");
+
+        createLogRecords(100, cal, currentDate, sdf);
+
+        handler.setPruneSize(100L);
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+
+        cal.add(Calendar.DAY_OF_MONTH, -1);
+
+        List<Path> files = Files.list(BASE_LOG_DIR.toPath()).collect(Collectors.toList());
+        Assert.assertEquals(2, files.size());
+        Assert.assertEquals("periodic-rotating-file-handler.log", files.get(0).getFileName().toString());
+        Assert.assertEquals("periodic-rotating-file-handler.log." + sdf.format(cal.getTime()), files.get(1).getFileName().toString());
+
+    }
+
+    @Test
+    public void testPruneIgnoreExtraFilesInDir() throws Exception {
+
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+
+        Files.createFile(Paths.get(BASE_LOG_DIR.toString(), "chaff.txt"));
+
+        String currentDate = sdf.format(cal.getTime());
+        handler.setSuffix(".YYYY-MM-dd");
+
+        createLogRecords(10, cal, currentDate, sdf);
+
+        handler.setPruneSize(50L);
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+
+        cal.add(Calendar.DAY_OF_MONTH, -1);
+
+        List<File> files = Files
+            .list(BASE_LOG_DIR.toPath())
+            .map(Path::toFile)
+            .sorted(Comparator.comparingLong(File::lastModified).reversed())
+            .collect(Collectors.toList());
+        Assert.assertEquals(3, files.size());
+        Assert.assertEquals("periodic-rotating-file-handler.log", files.get(0).getName());
+        Assert.assertEquals("periodic-rotating-file-handler.log." + sdf.format(cal.getTime()), files.get(1).getName());
+        Assert.assertEquals("chaff.txt", files.get(2).getName());
+
+    }
+
+    @Test
+    public void testPruneIgnoreFilesInNestedDir() throws Exception {
+
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+
+        Files.createDirectories(Paths.get(BASE_LOG_DIR.toString(), "nested"));
+        Files.createFile(Paths.get(BASE_LOG_DIR.toString(), "nested", "periodic-rotating-file-handler.log.2019-10-15"));
+
+        String currentDate = sdf.format(cal.getTime());
+        handler.setSuffix(".YYYY-MM-dd");
+
+        createLogRecords(10, cal, currentDate, sdf);
+
+        handler.setPruneSize(50L);
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+
+        cal.add(Calendar.DAY_OF_MONTH, -1);
+
+        List<File> files = Files
+            .list(BASE_LOG_DIR.toPath())
+            .map(Path::toFile)
+            .sorted(Comparator.comparingLong(File::lastModified).reversed())
+            .collect(Collectors.toList());
+        files.forEach(System.out::println);
+        Assert.assertEquals(3, files.size());
+        Assert.assertEquals("periodic-rotating-file-handler.log", files.get(0).getName());
+        Assert.assertEquals("periodic-rotating-file-handler.log." + sdf.format(cal.getTime()), files.get(1).getName());
+        Assert.assertEquals("nested", files.get(2).getName());
+    }
+
+    @Test
+    public void testPruneIgnoreSymlinks() throws Exception {
+
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+        final Path rotatedFile = BASE_LOG_DIR.toPath().resolve(FILENAME + rotateFormatter.format(cal.getTime()));
+
+        Path temp = Files.createTempFile("mytemp", ".tmp");
+        Path linkPath = Files.createLink(Paths.get(BASE_LOG_DIR.toString(), "mytemp"), temp);
+        Assert.assertTrue(linkPath.toFile().exists());
+
+        String currentDate = sdf.format(cal.getTime());
+        handler.setSuffix(".YYYY-MM-dd");
+
+        createLogRecords(10, cal, currentDate, sdf);
+
+        handler.setPruneSize(50L);
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+
+        cal.add(Calendar.DAY_OF_MONTH, -1);
+
+        List<File> files = Files
+            .list(BASE_LOG_DIR.toPath())
+            .map(Path::toFile)
+            .sorted(Comparator.comparingLong(File::lastModified).reversed())
+            .collect(Collectors.toList());
+        Assert.assertEquals(3, files.size());
+        Assert.assertEquals("periodic-rotating-file-handler.log", files.get(0).getName());
+        Assert.assertEquals("periodic-rotating-file-handler.log." + sdf.format(cal.getTime()), files.get(1).getName());
+        Assert.assertEquals("mytemp", files.get(2).getName());
+
+    }
+
+    @Test
+    public void testPruneIgnoreFilesWithInsufficientPerms() throws Exception {
+
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+        final Path rotatedFile = BASE_LOG_DIR.toPath().resolve(FILENAME + rotateFormatter.format(cal.getTime()));
+
+        Path roFile = Files.createFile(Paths.get(BASE_LOG_DIR.toString(), "periodic-rotating-file-handler.log.foo"),
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("r--------"))
+        );
+        Assert.assertFalse(roFile.toFile().canWrite());
+
+        String currentDate = sdf.format(cal.getTime());
+        handler.setSuffix(".YYYY-MM-dd");
+
+        createLogRecords(10, cal, currentDate, sdf);
+
+        handler.setPruneSize(50L);
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+
+        cal.add(Calendar.DAY_OF_MONTH, -1);
+
+        List<File> files = Files
+            .list(BASE_LOG_DIR.toPath())
+            .map(Path::toFile)
+            .sorted(Comparator.comparingLong(File::lastModified).reversed())
+            .collect(Collectors.toList());
+        Assert.assertEquals(3, files.size());
+        Assert.assertEquals("periodic-rotating-file-handler.log", files.get(0).getName());
+        Assert.assertEquals("periodic-rotating-file-handler.log." + sdf.format(cal.getTime()), files.get(1).getName());
+        Assert.assertEquals("periodic-rotating-file-handler.log.foo", files.get(2).getName());
+
+        Assert.assertTrue(roFile.toFile().setWritable(true));
+        Assert.assertTrue(roFile.toFile().setExecutable(true));
+
+    }
+
+    @Test
+    public void testPruneArchive() throws Exception {
+
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+        final Path rotatedFile = BASE_LOG_DIR.toPath().resolve(FILENAME + rotateFormatter.format(cal.getTime()));
+
+        String currentDate = sdf.format(cal.getTime());
+        handler.setSuffix(".YYYY-MM-dd.zip");
+
+        for (int i = 0; i < 10; i++) {
+
+            // Create a log message to be logged
+            ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+            record.setMillis(cal.getTimeInMillis());
+            handler.publish(record);
+
+            Assert.assertTrue("File '" + logFile + "' does not exist", Files.exists(logFile));
+
+            // Read the contents of the log file and ensure there's only one line
+            List<String> lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+            Assert.assertEquals("More than 1 line found", 1, lines.size());
+            Assert.assertTrue("Expected the line to contain the date: " + currentDate, lines.get(0).contains(currentDate));
+
+            cal.add(Calendar.DAY_OF_MONTH, 1);
+            cal.add(Calendar.MINUTE, 1);
+            currentDate = sdf.format(cal.getTime());
+        }
+
+        handler.setPruneSize(400L);
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+
+        cal.add(Calendar.DAY_OF_MONTH, -1);
+
+        List<Path> files = Files.list(BASE_LOG_DIR.toPath()).collect(Collectors.toList());
+        Assert.assertEquals(2, files.size());
+        Assert.assertEquals("periodic-rotating-file-handler.log", files.get(0).getFileName().toString());
+        Assert.assertEquals("periodic-rotating-file-handler.log." + sdf.format(cal.getTime()) + ".zip", files.get(1).getFileName().toString());
+
+    }
+
+    private void createLogRecords(int number, Calendar now, String currentDate, SimpleDateFormat formatter) throws Exception {
+        for (int i = 0; i < number; i++) {
+
+            // Create a log message to be logged
+            ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+            record.setMillis(now.getTimeInMillis());
+            handler.publish(record);
+
+            // introduce a small pause to ensure that tests are determinate
+            Thread.sleep(25L);
+
+            Assert.assertTrue("File '" + logFile + "' does not exist", Files.exists(logFile));
+
+            // Read the contents of the log file and ensure there's only one line
+            List<String> lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+            Assert.assertEquals("More than 1 line found", 1, lines.size());
+            Assert.assertTrue("Expected the line to contain the date: " + currentDate, lines.get(0).contains(currentDate));
+
+            now.add(Calendar.DAY_OF_MONTH, 1);
+            now.add(Calendar.MINUTE, 1);
+            currentDate = formatter.format(now.getTime());
+
+        }
+    }
 
     private void testRotate(final Calendar cal, final Path rotatedFile) throws Exception {
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");

--- a/ext/src/test/java/org/jboss/logmanager/ext/handlers/PeriodicRotatingFileHandlerTests.java
+++ b/ext/src/test/java/org/jboss/logmanager/ext/handlers/PeriodicRotatingFileHandlerTests.java
@@ -75,7 +75,6 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
         handler.close();
         handler = null;
         Files.list(BASE_LOG_DIR.toPath()).forEach(p -> {
-            System.out.println("deleting file " + p);
             try {
                 File f = p.toFile();
                 if (!f.isDirectory()) {
@@ -179,7 +178,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
 
         createLogRecords(10, cal, currentDate, sdf);
 
-        handler.setPruneSize(50L);
+        handler.setPruneSize("50");
         ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
         record.setMillis(cal.getTimeInMillis());
         handler.publish(record);
@@ -193,6 +192,66 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
 
     }
 
+    @Test
+    public void testPrunePeriods() throws Exception {
+
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+
+        String currentDate = sdf.format(cal.getTime());
+        handler.setSuffix(".YYYY-MM-dd");
+
+        createLogRecords(10, cal, currentDate, sdf);
+
+        handler.setPruneSize("5p");
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+
+        cal.add(Calendar.DAY_OF_MONTH, -1);
+
+        List<Path> files = Files
+            .list(BASE_LOG_DIR.toPath())
+            .sorted(Comparator.comparingLong(p -> ((Path) p).toFile().lastModified()).reversed())
+            .collect(Collectors.toList());
+        files.forEach(System.out::println);
+        Assert.assertEquals(6, files.size());
+        Assert.assertEquals("periodic-rotating-file-handler.log", files.get(0).getFileName().toString());
+        for (int i = 0; i < 5; i++) {
+            Assert.assertEquals("periodic-rotating-file-handler.log." + sdf.format(cal.getTime()), files.get(i + 1).getFileName().toString());
+            cal.add(Calendar.DAY_OF_MONTH, -1);
+        }
+
+    }
+
+    @Test
+    public void testPruneInvalidSize() throws Exception {
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+        String currentDate = sdf.format(cal.getTime());
+        handler.setSuffix(".YYYY-MM-dd");
+        createLogRecords(10, cal, currentDate, sdf);
+
+        handler.setPruneSize("-50");
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+    }
+    @Test
+    public void testPruneInvalidPeriods() throws Exception {
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+        String currentDate = sdf.format(cal.getTime());
+        handler.setSuffix(".YYYY-MM-dd");
+        createLogRecords(10, cal, currentDate, sdf);
+
+        handler.setPruneSize("-5p");
+        ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
+        record.setMillis(cal.getTimeInMillis());
+        handler.publish(record);
+    }
+
+
     @Test(timeout = 5000L)
     public void testPruneLarge() throws Exception {
 
@@ -204,7 +263,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
 
         createLogRecords(100, cal, currentDate, sdf);
 
-        handler.setPruneSize(100L);
+        handler.setPruneSize("100");
         ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
         record.setMillis(cal.getTimeInMillis());
         handler.publish(record);
@@ -231,7 +290,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
 
         createLogRecords(10, cal, currentDate, sdf);
 
-        handler.setPruneSize(50L);
+        handler.setPruneSize("50");
         ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
         record.setMillis(cal.getTimeInMillis());
         handler.publish(record);
@@ -264,7 +323,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
 
         createLogRecords(10, cal, currentDate, sdf);
 
-        handler.setPruneSize(50L);
+        handler.setPruneSize("50");
         ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
         record.setMillis(cal.getTimeInMillis());
         handler.publish(record);
@@ -299,7 +358,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
 
         createLogRecords(10, cal, currentDate, sdf);
 
-        handler.setPruneSize(50L);
+        handler.setPruneSize("50");
         ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
         record.setMillis(cal.getTimeInMillis());
         handler.publish(record);
@@ -335,7 +394,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
 
         createLogRecords(10, cal, currentDate, sdf);
 
-        handler.setPruneSize(50L);
+        handler.setPruneSize("50");
         ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
         record.setMillis(cal.getTimeInMillis());
         handler.publish(record);
@@ -386,7 +445,7 @@ public class PeriodicRotatingFileHandlerTests extends AbstractHandlerTest {
             currentDate = sdf.format(cal.getTime());
         }
 
-        handler.setPruneSize(400L);
+        handler.setPruneSize("400");
         ExtLogRecord record = createLogRecord(Level.INFO, "Date: %s", currentDate);
         record.setMillis(cal.getTimeInMillis());
         handler.publish(record);

--- a/ext/src/test/resources/configs/prune-logging.properties
+++ b/ext/src/test/resources/configs/prune-logging.properties
@@ -1,0 +1,47 @@
+#
+# JBoss, Home of Professional Open Source.
+#
+# Copyright 2014 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+loggers=org.jboss.logmanager
+
+# Root logger
+logger.level=INFO
+logger.handlers=CONSOLE,FILE
+
+logger.org.jboss.logmanager.useParentHandlers=true
+logger.org.jboss.logmanager.level=INFO
+
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.formatter=PATTERN
+handler.CONSOLE.properties=autoFlush,target
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.target=SYSTEM_OUT
+
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.formatter=PATTERN
+handler.FILE.level=TRACE
+handler.FILE.properties=autoFlush,append,fileName
+handler.FILE.constructorProperties=fileName,append
+handler.FILE.autoFlush=true
+handler.FILE.append=false
+handler.FILE.fileName=${log.dir:target}/test.log
+handler.FILE.encoding=UTF-8
+handler.FILE.pruneSize=50
+
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n


### PR DESCRIPTION
Took a look at LOGMGR-139, and I've got a simple implementation that I think will handle the majority of use cases.

The implementation adds a property, (pruneSize) on the PeriodicRotatingFileHandler. It defaults to zero. If it is set to > 0, it enables log pruning, which automatically removes old log files until some criteria is met. Pruning functionality operates on files in the directory of the current log file only, to a max depth of 1.

The prune size can be set to one of two options:

A long: Prunes files (oldest first) until the total size of pruneable files found <= pruneSize
An integer with a trailing 'P' or 'p': Prunes any log period files older than <pruneSize> periods. Ex: "5p".

Files eligible for pruning have the following qualities:
* not the current log file
* regular (not directories, hidden, or symlinks)
* writable by the current executing user
* names that start with the current log name (so, if the current log name is "server.log", things like "server.log.foo", "server.log.2019-10-03", etc)
 
The implementation is simple; it doesn't handle edge cases like changed log directories. It's based on the assumption that the vast majority of users put their logs in one directory that they set once and very rarely change. I've added some tests as well. Hope that it is useful; let me know your thoughts!