### PR TITLE
[LOGMGR-264] Allow for loggers to log to different log contexts based…

### DIFF
--- a/src/main/java/org/jboss/logmanager/ContextualLoggerNode.java
+++ b/src/main/java/org/jboss/logmanager/ContextualLoggerNode.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.util.logging.Filter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+interface ContextualLoggerNode {
+
+    @SuppressWarnings({"Convert2Lambda"})
+    static ContextualLoggerNode of(final LoggerNode defaultNode, final String name) {
+        return new ContextualLoggerNode() {
+            @Override
+            public LoggerNode getLoggerNode() {
+                if (LogContextRouter.isEnabled()) {
+                    final LoggerNode result = LogContextRouter.getInstance().getLoggerNode(name);
+                    return result == null ? defaultNode : result;
+                }
+                return defaultNode;
+            }
+        };
+    }
+
+    default void decrementRef() {
+        getLoggerNode().decrementRef();
+    }
+
+    default LogContext getContext() {
+        return getLoggerNode().getContext();
+    }
+
+    default void setFilter(final Filter filter) {
+        getLoggerNode().setFilter(filter);
+    }
+
+    default Filter getFilter() {
+        return getLoggerNode().getFilter();
+    }
+
+    default boolean getUseParentFilters() {
+        return getLoggerNode().getUseParentFilters();
+    }
+
+    default void setUseParentFilters(final boolean useParentFilter) {
+        getLoggerNode().setUseParentFilters(useParentFilter);
+    }
+
+    default int getEffectiveLevel() {
+        return getLoggerNode().getEffectiveLevel();
+    }
+
+    default Handler[] getHandlers() {
+        return getLoggerNode().getHandlers();
+    }
+
+    default Handler[] clearHandlers() {
+        return getLoggerNode().clearHandlers();
+    }
+
+    default void removeHandler(final Handler handler) {
+        getLoggerNode().removeHandler(handler);
+    }
+
+    default void addHandler(final Handler handler) {
+        getLoggerNode().addHandler(handler);
+    }
+
+    default Handler[] setHandlers(final Handler[] handlers) {
+        return getLoggerNode().setHandlers(handlers);
+    }
+
+    default boolean compareAndSetHandlers(final Handler[] oldHandlers, final Handler[] newHandlers) {
+        return getLoggerNode().compareAndSetHandlers(oldHandlers, newHandlers);
+    }
+
+    default boolean getUseParentHandlers() {
+        return getLoggerNode().getUseParentHandlers();
+    }
+
+    default void setUseParentHandlers(final boolean useParentHandlers) {
+        getLoggerNode().setUseParentHandlers(useParentHandlers);
+    }
+
+    default void publish(final ExtLogRecord record) {
+        getLoggerNode().publish(record);
+    }
+
+    default void setLevel(final Level newLevel) {
+        getLoggerNode().setLevel(newLevel);
+    }
+
+    default Level getLevel() {
+        return getLoggerNode().getLevel();
+    }
+
+    default <V> V getAttachment(final Logger.AttachmentKey<V> key) {
+        return getLoggerNode().getAttachment(key);
+    }
+
+    default <V> V attach(final Logger.AttachmentKey<V> key, final V value) {
+        return getLoggerNode().attach(key, value);
+    }
+
+    default <V> V attachIfAbsent(final Logger.AttachmentKey<V> key, final V value) {
+        return getLoggerNode().attachIfAbsent(key, value);
+    }
+
+    default <V> V detach(final Logger.AttachmentKey<V> key) {
+        return getLoggerNode().detach(key);
+    }
+
+    default LoggerNode getParent() {
+        return getLoggerNode().getParent();
+    }
+
+    default boolean isLoggable(final ExtLogRecord record) {
+        return getLoggerNode().isLoggable(record);
+    }
+
+    LoggerNode getLoggerNode();
+}

--- a/src/main/java/org/jboss/logmanager/LogContextRouter.java
+++ b/src/main/java/org/jboss/logmanager/LogContextRouter.java
@@ -1,0 +1,152 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A router used to route log messages to a specific log context based on the current threads
+ * {@linkplain Thread#getContextClassLoader() context class loader}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("unused")
+public class LogContextRouter {
+    private static final LogContextRouter INSTANCE = new LogContextRouter();
+    private static volatile boolean ENABLED = false;
+    private final Map<ClassLoader, ContextualLoggerNodes> contexts;
+
+    private LogContextRouter() {
+        contexts = new HashMap<>();
+    }
+
+    /**
+     * Gets the instance of the router.
+     *
+     * @return the router
+     */
+    public static LogContextRouter getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Checks if the routing is enabled.
+     *
+     * @return {@code true} if the router is enabled, otherwise {@code false}
+     */
+    static boolean isEnabled() {
+        return ENABLED;
+    }
+
+    /**
+     * Gets or creates a logger node.
+     *
+     * @param name the name of the logger nod to create
+     *
+     * @return the logger node or {@code null} if there is no {@link LogContext} associated with the
+     * {@linkplain Thread#getContextClassLoader() TCCL}
+     */
+    LoggerNode getLoggerNode(final String name) {
+        final ClassLoader tccl = getTccl();
+        if (tccl == null) {
+            return null;
+        }
+        synchronized (contexts) {
+            final ContextualLoggerNodes value = contexts.get(tccl);
+            return value == null ? null : value.getLoggerNode(name);
+        }
+    }
+
+    /**
+     * Registers the log context the class loader should route log messages to.
+     *
+     * @param cl         the class loader which should route messages based on the {@linkplain Thread#getContextClassLoader() TCCL}
+     * @param logContext the context messages should be routed to
+     *
+     * @return this router
+     */
+    public LogContextRouter register(final ClassLoader cl, final LogContext logContext) {
+        synchronized (contexts) {
+            contexts.putIfAbsent(cl, new ContextualLoggerNodes(logContext));
+            ENABLED = !contexts.isEmpty();
+        }
+        return this;
+    }
+
+    /**
+     * Removes class loader from routing.
+     *
+     * @param cl the class loader to remove from routing
+     *
+     * @return this router
+     */
+    public LogContextRouter unregister(final ClassLoader cl) {
+        synchronized (contexts) {
+            final ContextualLoggerNodes removed = contexts.remove(cl);
+            if (removed != null) {
+                removed.clear();
+            }
+            ENABLED = !contexts.isEmpty();
+        }
+        return this;
+    }
+
+    @SuppressWarnings("Convert2Lambda")
+    private static ClassLoader getTccl() {
+        if (System.getSecurityManager() == null) {
+            return Thread.currentThread().getContextClassLoader();
+        }
+        return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+            @Override
+            public ClassLoader run() {
+                return Thread.currentThread().getContextClassLoader();
+            }
+        });
+    }
+
+    private static class ContextualLoggerNodes {
+        final LogContext logContext;
+        final Map<String, LoggerNode> nodes;
+
+        private ContextualLoggerNodes(final LogContext logContext) {
+            this.logContext = logContext;
+            nodes = new CopyOnWriteWeakMap<>();
+        }
+
+        LoggerNode getLoggerNode(final String name) {
+            LoggerNode result = nodes.get(name);
+            if (result == null) {
+                result = logContext.getRootLoggerNode().getOrCreate(name);
+                final LoggerNode appearing = nodes.putIfAbsent(name, result);
+                if (appearing != null) {
+                    return appearing;
+                }
+            }
+            return result;
+        }
+
+        void clear() {
+            nodes.clear();
+        }
+    }
+}

--- a/src/main/java/org/jboss/logmanager/Logger.java
+++ b/src/main/java/org/jboss/logmanager/Logger.java
@@ -39,7 +39,7 @@ public final class Logger extends java.util.logging.Logger implements Serializab
     /**
      * The named logger tree node.
      */
-    private final LoggerNode loggerNode;
+    private final ContextualLoggerNode loggerNode;
 
     private static final String LOGGER_CLASS_NAME = Logger.class.getName();
 
@@ -80,7 +80,7 @@ public final class Logger extends java.util.logging.Logger implements Serializab
      * @param loggerNode the node in the named logger tree
      * @param name the fully-qualified name of this node
      */
-    Logger(final LoggerNode loggerNode, final String name) {
+    Logger(final ContextualLoggerNode loggerNode, final String name) {
         // Don't set up the bundle in the parent...
         super(name, null);
         // We have to propagate our level to an internal data structure in the superclass

--- a/src/main/java/org/jboss/logmanager/LoggerNode.java
+++ b/src/main/java/org/jboss/logmanager/LoggerNode.java
@@ -220,13 +220,13 @@ final class LoggerNode implements AutoCloseable {
         if (sm != null) {
             return AccessController.doPrivileged(new PrivilegedAction<Logger>() {
                 public Logger run() {
-                    final Logger logger = new Logger(LoggerNode.this, fullName);
+                    final Logger logger = new Logger(ContextualLoggerNode.of(LoggerNode.this, fullName), fullName);
                     context.incrementRef(fullName);
                     return logger;
                 }
             });
         } else {
-            final Logger logger = new Logger(this, fullName);
+            final Logger logger = new Logger(ContextualLoggerNode.of(this, fullName), fullName);
             context.incrementRef(fullName);
             return logger;
         }


### PR DESCRIPTION
… on the TCCL if the class loader was registered with the log router.

https://issues.jboss.org/browse/LOGMGR-264

Note it's debatable whether or not this is appropriate for 2.1.x as it is a behavioral change. However the behavior is not changed by default.