### PR TITLE
[LOGMGR-263] Instead of getting all the classes on the call stack pro…

### DIFF
--- a/src/main/java/org/jboss/logmanager/ClassLoaderLogContextSelector.java
+++ b/src/main/java/org/jboss/logmanager/ClassLoaderLogContextSelector.java
@@ -20,12 +20,12 @@
 package org.jboss.logmanager;
 
 import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.Permission;
-import java.util.Collection;
+import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 
 /**
  * A log context selector which chooses a log context based on the caller's classloader.
@@ -88,28 +88,29 @@ public final class ClassLoaderLogContextSelector implements LogContextSelector {
     private final Set<ClassLoader> logApiClassLoaders = Collections.newSetFromMap(new CopyOnWriteMap<ClassLoader, Boolean>());
     private final boolean checkParentClassLoaders;
 
-    private final PrivilegedAction<LogContext> logContextAction = new PrivilegedAction<LogContext>() {
-        public LogContext run() {
-            final Collection<Class<?>> callingClasses = JDKSpecific.findCallingClasses(logApiClassLoaders);
-            for (Class<?> caller : callingClasses) {
-                final LogContext result = check(caller.getClassLoader());
-                if (result != null) {
-                    return result;
-                }
-            }
-            return defaultSelector.getLogContext();
-        }
+    private final Function<ClassLoader, LogContext> logContextFinder = new Function<ClassLoader, LogContext>() {
+        @Override
+        public LogContext apply(final ClassLoader classLoader) {
 
-        private LogContext check(final ClassLoader classLoader) {
             final LogContext context = contextMap.get(classLoader);
             if (context != null) {
                 return context;
             }
             final ClassLoader parent = classLoader.getParent();
-            if (parent != null && checkParentClassLoaders && ! logApiClassLoaders.contains(parent)) {
-                return check(parent);
+            if (parent != null && checkParentClassLoaders && !logApiClassLoaders.contains(parent)) {
+                return apply(parent);
             }
             return null;
+        }
+    };
+
+    private final PrivilegedAction<LogContext> logContextAction = new PrivilegedAction<LogContext>() {
+        public LogContext run() {
+            final LogContext result = JDKSpecific.logContextFinder(logApiClassLoaders, logContextFinder);
+            if (result != null) {
+                return result;
+            }
+            return defaultSelector.getLogContext();
         }
     };
 

--- a/src/main/java/org/jboss/logmanager/JDKSpecific.java
+++ b/src/main/java/org/jboss/logmanager/JDKSpecific.java
@@ -21,9 +21,8 @@ package org.jboss.logmanager;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.jboss.modules.Module;
 import org.jboss.modules.Version;
@@ -69,15 +68,17 @@ final class JDKSpecific {
         return null;
     }
 
-    static Collection<Class<?>> findCallingClasses(Set<ClassLoader> rejectClassLoaders) {
-        final Collection<Class<?>> result = new LinkedHashSet<>();
+    static LogContext logContextFinder(Set<ClassLoader> rejectClassLoaders, final Function<ClassLoader, LogContext> finder) {
         for (Class<?> caller : GATEWAY.getClassContext()) {
             final ClassLoader classLoader = caller.getClassLoader();
             if (classLoader != null && !rejectClassLoaders.contains(classLoader)) {
-                result.add(caller);
+                final LogContext result = finder.apply(classLoader);
+                if (result != null) {
+                    return result;
+                }
             }
         }
-        return result;
+        return null;
     }
 
     static void calculateCaller(ExtLogRecord logRecord) {


### PR DESCRIPTION
…cess the call stack and check for a registered log context in cases where the full call stack are not required.

https://issues.redhat.com/browse/LOGMGR-263