### PR TITLE
[LOGMGR-273] - Fix javadoc on Java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <org.jboss.test.port>4560</org.jboss.test.port>
         <org.jboss.test.alt.port>14560</org.jboss.test.alt.port>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
 
         <jdk.min.version>9</jdk.min.version>
     </properties>


### PR DESCRIPTION

Issue: [LOGMGR-273](https://issues.redhat.com/browse/LOGMGR-273)
Solution based on https://github.com/assertj/assertj-parent-pom/commit/9b521bc33ac81b9a809de39c00599a9f928934d8