### PR TITLE
[LOGMGR-276] Ensure the file is not null before attempting to rotate it.

### DIFF
--- a/ext/src/main/java/org/jboss/logmanager/ext/handlers/PeriodicRotatingFileHandler.java
+++ b/ext/src/main/java/org/jboss/logmanager/ext/handlers/PeriodicRotatingFileHandler.java
@@ -197,6 +197,10 @@ public class PeriodicRotatingFileHandler extends FileHandler {
     private void rollOver() {
         try {
             final File file = getFile();
+            if (file == null) {
+                // no file is set; a direct output stream or writer was specified
+                return;
+            }
             // first, close the original file (some OSes won't let you move/rename a file that is open)
             setFileInternal(null);
             // next, rotate it


### PR DESCRIPTION
https://issues.redhat.com/browse/LOGMGR-276