### PR TITLE
[LOGMGR-280] SocketHandlerTests hangs on some JDKs

### DIFF
--- a/src/test/java/org/jboss/logmanager/handlers/SocketHandlerTests.java
+++ b/src/test/java/org/jboss/logmanager/handlers/SocketHandlerTests.java
@@ -20,6 +20,7 @@ import org.jboss.logmanager.config.LogContextConfiguration;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.SocketHandler.Protocol;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -30,6 +31,11 @@ public class SocketHandlerTests extends AbstractHandlerTest {
     private final InetAddress address;
     private final int port;
     private final int altPort;
+
+    // https://bugs.openjdk.java.net/browse/JDK-8219991
+    private final String JAVA_VERSION = System.getProperty("java.version");
+    private final String JDK_8219991_ERROR_MESSAGE = "https://bugs.openjdk.java.net/browse/JDK-8219991";
+    private final Boolean JDK_8219991 = JAVA_VERSION.startsWith("1.8") || (JAVA_VERSION.startsWith("11.0.8") && System.getProperty("java.vendor").contains("Oracle"));
 
     public SocketHandlerTests() throws UnknownHostException {
         address = InetAddress.getByName(System.getProperty("org.jboss.test.address", "127.0.0.1"));
@@ -108,6 +114,7 @@ public class SocketHandlerTests extends AbstractHandlerTest {
 
     @Test
     public void testProtocolChange() throws Exception {
+        Assume.assumeFalse(JDK_8219991_ERROR_MESSAGE, JDK_8219991);
         try (SocketHandler handler = createHandler(Protocol.TCP)) {
             try (SimpleServer server = SimpleServer.createTcpServer(port)) {
                 final ExtLogRecord record = createLogRecord("Test TCP handler");
@@ -171,6 +178,7 @@ public class SocketHandlerTests extends AbstractHandlerTest {
 
     @Test
     public void testTlsConfig() throws Exception {
+        Assume.assumeFalse(JDK_8219991_ERROR_MESSAGE, JDK_8219991);
         try (SimpleServer server = SimpleServer.createTlsServer(port)) {
             final LogContext logContext = LogContext.create();
             final LogContextConfiguration logContextConfiguration = LogContextConfiguration.Factory.create(logContext);


### PR DESCRIPTION
See the details (CI runs included) on comments on upstream jira: https://issues.redhat.com/browse/LOGMGR-280

Main JDK jira: https://bugs.openjdk.java.net/browse/JDK-8219991

Issue won't be fixed in JDK8 (see https://bugs.openjdk.java.net/browse/JDK-8253471 ), so I ignore affected test methods for all JDK8

Issue is fixed in OpenJDK 11.0.8 ( https://bugs.openjdk.java.net/browse/JDK-8241217 ). Issue will be fixed in OracleJDK 11.0.9 ( https://bugs.openjdk.java.net/browse/JDK-8247345 )

2.1 PR (this one): https://github.com/jboss-logging/jboss-logmanager/pull/318
2.2 PR: https://github.com/jboss-logging/jboss-logmanager/pull/321
2.3 PR: https://github.com/jboss-logging/jboss-logmanager/pull/319
master PR: https://github.com/jboss-logging/jboss-logmanager/pull/320