### PR TITLE
[LOGMGR-281] Match the nesting and labeling of the fix introduced in …

### DIFF
--- a/core/src/main/java/org/jboss/logmanager/formatters/StackTraceFormatter.java
+++ b/core/src/main/java/org/jboss/logmanager/formatters/StackTraceFormatter.java
@@ -117,7 +117,9 @@ public class StackTraceFormatter {
 
     private void renderStackTrace(final StackTraceElement[] parentStack, final Throwable child, final String caption, final String prefix) {
         if (seen.contains(child)) {
-            builder.append("\t[CIRCULAR REFERENCE:")
+            builder.append(prefix)
+                    .append(caption)
+                    .append("[CIRCULAR REFERENCE: ")
                     .append(child)
                     .append(']');
             newLine();

--- a/core/src/main/java9/org/jboss/logmanager/formatters/StackTraceFormatter.java
+++ b/core/src/main/java9/org/jboss/logmanager/formatters/StackTraceFormatter.java
@@ -95,7 +95,9 @@ public class StackTraceFormatter {
 
     private void renderStackTrace(final StackTraceElement[] parentStack, final Throwable child, final String caption, final String prefix) {
         if (seen.contains(child)) {
-            builder.append("\t[CIRCULAR REFERENCE:")
+            builder.append(prefix)
+                    .append(caption)
+                    .append("[CIRCULAR REFERENCE: ")
                     .append(child)
                     .append(']');
             newLine();

--- a/core/src/test/java/org/jboss/logmanager/formatters/PatternFormatterTests.java
+++ b/core/src/test/java/org/jboss/logmanager/formatters/PatternFormatterTests.java
@@ -245,7 +245,7 @@ public class PatternFormatterTests {
         formatter = new PatternFormatter("%e");
         cause.addSuppressed(suppressedLevel1);
         formatted = formatter.format(record);
-        Assert.assertTrue(formatted.contains("CIRCULAR REFERENCE:java.lang.IllegalStateException: suppressedLevel1"));
+        Assert.assertTrue(formatted.contains("CIRCULAR REFERENCE: java.lang.IllegalStateException: suppressedLevel1"));
     }
 
     @Test


### PR DESCRIPTION
…JDK-8226809.

https://issues.redhat.com/browse/LOGMGR-281
https://bugs.openjdk.java.net/browse/JDK-8226809