### PR TITLE
Use the java.home path for the javadoc executable. This works around …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <doclint>none</doclint>
+                    <javadocExecutable>${java.home}${file.separator}bin</javadocExecutable>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
…issues when the JAVA_HOME environment variable is not set.