### PR TITLE
Use the java.home path for the javadoc executable. This works around …

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -81,12 +81,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <doclint>none</doclint>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,15 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>            
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <doclint>none</doclint>
+                    <javadocExecutable>${java.home}${file.separator}bin</javadocExecutable>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>


### PR DESCRIPTION
…issues when the JAVA_HOME environment variable is not set.