### PR TITLE
support for SLF4J Markers 

### DIFF
--- a/core/src/main/java/org/jboss/logmanager/ExtLogRecord.java
+++ b/core/src/main/java/org/jboss/logmanager/ExtLogRecord.java
@@ -121,6 +121,7 @@ public class ExtLogRecord extends LogRecord {
         hostName = original.hostName;
         processName = original.processName;
         processId = original.processId;
+        metadata = original.metadata;
     }
 
     /**
@@ -144,7 +145,7 @@ public class ExtLogRecord extends LogRecord {
     private transient boolean calculateCaller = true;
 
     private String ndc;
-    private FormatStyle formatStyle = FormatStyle.MESSAGE_FORMAT;
+    private FormatStyle formatStyle;
     private FastCopyHashMap<String, Object> mdcCopy;
     private int sourceLineNumber = -1;
     private String sourceFileName;
@@ -154,6 +155,7 @@ public class ExtLogRecord extends LogRecord {
     private long processId = -1;
     private String sourceModuleName;
     private String sourceModuleVersion;
+    private Object metadata;
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
         copyAll();
@@ -174,6 +176,7 @@ public class ExtLogRecord extends LogRecord {
         processId = fields.get("processId", -1L);
         sourceModuleName = (String) fields.get("sourceModuleName", null);
         sourceModuleVersion = (String) fields.get("sourceModuleVersion", null);
+        metadata = fields.get("metadata", null);
     }
 
     /**
@@ -617,5 +620,17 @@ public class ExtLogRecord extends LogRecord {
      */
     public void setResourceBundleName(final String name) {
         super.setResourceBundleName(name);
+    }
+
+    /**
+     * Set the metadata for this event. This could be used to pass additional information (such as SLF4J Markers).
+     * @param metadata metadata (may be null).
+     */
+    public void setMetadata(final Object metadata) {
+        this.metadata = metadata;
+    }
+
+    public Object getMetadata() {
+        return metadata;
     }
 }


### PR DESCRIPTION
Tentative implementation for:
https://github.com/quarkusio/quarkus/issues/15193

The idea is to allowing passing SLF4J Marker as metadata in `slf4j-jboss-logmanager`:

```
 private void log(final Marker marker, final java.util.logging.Level level,  final String fqcn, final String message, final Throwable t, final Object[] params) {
        final ExtLogRecord rec = new ExtLogRecord(level, message, ExtLogRecord.FormatStyle.NO_FORMAT, fqcn);
        rec.setThrown(t);
        rec.setParameters(params);
        rec.setMetadata(marker); <--- todo
        logger.logRaw(rec);
    }
```

Then `Slf4jLogger` should be changed to fully implement the SLF4J logger interface (i.e. removing `MarkerIgnoringBase`). 
The constraint is that metadata must be typed as `java.lang.Object` (to avoid strong and direct dependency to slf4j-api).