### PR TITLE
adding marker property to ExLogRecord

### DIFF
--- a/core/src/main/java/org/jboss/logmanager/ExtLogRecord.java
+++ b/core/src/main/java/org/jboss/logmanager/ExtLogRecord.java
@@ -144,7 +144,7 @@ public class ExtLogRecord extends LogRecord {
     private transient boolean calculateCaller = true;
 
     private String ndc;
-    private FormatStyle formatStyle = FormatStyle.MESSAGE_FORMAT;
+    private FormatStyle formatStyle;
     private FastCopyHashMap<String, Object> mdcCopy;
     private int sourceLineNumber = -1;
     private String sourceFileName;
@@ -154,6 +154,7 @@ public class ExtLogRecord extends LogRecord {
     private long processId = -1;
     private String sourceModuleName;
     private String sourceModuleVersion;
+    private Object marker;
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
         copyAll();
@@ -174,6 +175,7 @@ public class ExtLogRecord extends LogRecord {
         processId = fields.get("processId", -1L);
         sourceModuleName = (String) fields.get("sourceModuleName", null);
         sourceModuleVersion = (String) fields.get("sourceModuleVersion", null);
+        marker = fields.get("marker", null);
     }
 
     /**
@@ -617,5 +619,16 @@ public class ExtLogRecord extends LogRecord {
      */
     public void setResourceBundleName(final String name) {
         super.setResourceBundleName(name);
+    }
+
+    /**
+     * Set the marker for this event. Markers are used mostly by SLF4J and Log4j.
+     */
+    public void setMarker(Object marker) {
+        this.marker = marker;
+    }
+
+    public Object getMarker() {
+        return marker;
     }
 }


### PR DESCRIPTION
This new property will be used to propagate the Marker to the actual
logging library. Since both SLF4J and Log4j define a different Marker
class without any common interface, here an Object is used.