### PR TITLE
[LOGMGR-294] Compare the logger class name instead of the instance to…

### DIFF
--- a/core/src/main/java9/org/jboss/logmanager/JBossLoggerFinder.java
+++ b/core/src/main/java9/org/jboss/logmanager/JBossLoggerFinder.java
@@ -66,7 +66,7 @@ public class JBossLoggerFinder extends System.LoggerFinder {
             }
         }
         final java.util.logging.Logger logger = java.util.logging.Logger.getLogger(name);
-        if (!(logger instanceof org.jboss.logmanager.Logger)) {
+        if (!logger.getClass().getName().equals("org.jboss.logmanager.Logger")) {
             if (LOGGED.compareAndSet(false, true)) {
                 logger.log(Level.ERROR, "The LogManager accessed before the \"java.util.logging.manager\" system property was set to \"org.jboss.logmanager.LogManager\". Results may be unexpected.");
             }


### PR DESCRIPTION
… avoid false positives if the log manager was loaded on two class loaders.

https://issues.redhat.com/browse/LOGMGR-294
Signed-off-by: James R. Perkins <jperkins@redhat.com>