### PR TITLE
Transition to smallrye-common, remove wildfly-common

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,8 +50,20 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.common</groupId>
-            <artifactId>wildfly-common</artifactId>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-constraint</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-net</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-os</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-ref</artifactId>
         </dependency>
 
         <!-- test dependencies -->
@@ -60,6 +72,12 @@
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Used by DelayedHandlerTests -->
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-cpu</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- JSON implementation -->

--- a/core/src/main/java/org/jboss/logmanager/ExtLogRecord.java
+++ b/core/src/main/java/org/jboss/logmanager/ExtLogRecord.java
@@ -19,6 +19,8 @@
 
 package org.jboss.logmanager;
 
+import io.smallrye.common.net.HostName;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -28,9 +30,6 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 import java.util.logging.LogRecord;
-
-import org.wildfly.common.net.HostName;
-import org.wildfly.common.os.Process;
 
 /**
  * An extended log record, which includes additional information including MDC/NDC and correct
@@ -85,8 +84,8 @@ public class ExtLogRecord extends LogRecord {
         ndc = NDC.get();
         threadName = Thread.currentThread().getName();
         hostName = HostName.getQualifiedHostName();
-        processName = Process.getProcessName();
-        processId = Process.getProcessId();
+        processName = io.smallrye.common.os.Process.getProcessName();
+        processId = io.smallrye.common.os.Process.getProcessId();
     }
 
     /**

--- a/core/src/main/java/org/jboss/logmanager/LogContext.java
+++ b/core/src/main/java/org/jboss/logmanager/LogContext.java
@@ -19,9 +19,9 @@
 
 package org.jboss.logmanager;
 
-import org.wildfly.common.Assert;
-import org.wildfly.common.ref.Reference;
-import org.wildfly.common.ref.References;
+import io.smallrye.common.constraint.Assert;
+import io.smallrye.common.ref.Reference;
+import io.smallrye.common.ref.References;
 
 import java.security.AccessController;
 import java.security.Permission;

--- a/core/src/main/java/org/jboss/logmanager/LogManager.java
+++ b/core/src/main/java/org/jboss/logmanager/LogManager.java
@@ -19,7 +19,7 @@
 
 package org.jboss.logmanager;
 
-import org.wildfly.common.Assert;
+import io.smallrye.common.constraint.Assert;
 
 import java.beans.PropertyChangeListener;
 import java.io.IOException;

--- a/core/src/main/java/org/jboss/logmanager/Logger.java
+++ b/core/src/main/java/org/jboss/logmanager/Logger.java
@@ -19,7 +19,7 @@
 
 package org.jboss.logmanager;
 
-import org.wildfly.common.Assert;
+import io.smallrye.common.constraint.Assert;
 
 import java.io.ObjectStreamException;
 import java.io.Serializable;

--- a/core/src/main/java/org/jboss/logmanager/LoggerNode.java
+++ b/core/src/main/java/org/jboss/logmanager/LoggerNode.java
@@ -19,10 +19,10 @@
 
 package org.jboss.logmanager;
 
-import org.wildfly.common.Assert;
-import org.wildfly.common.ref.PhantomReference;
-import org.wildfly.common.ref.Reaper;
-import org.wildfly.common.ref.Reference;
+import io.smallrye.common.constraint.Assert;
+import io.smallrye.common.ref.PhantomReference;
+import io.smallrye.common.ref.Reaper;
+import io.smallrye.common.ref.Reference;
 
 import java.lang.reflect.UndeclaredThrowableException;
 import java.security.AccessController;

--- a/core/src/main/java/org/jboss/logmanager/errormanager/HandlerErrorManager.java
+++ b/core/src/main/java/org/jboss/logmanager/errormanager/HandlerErrorManager.java
@@ -2,8 +2,8 @@ package org.jboss.logmanager.errormanager;
 
 import java.util.logging.Handler;
 
+import io.smallrye.common.constraint.Assert;
 import org.jboss.logmanager.ExtErrorManager;
-import org.wildfly.common.Assert;
 
 /**
  * An error manager which publishes errors to a handler.

--- a/core/src/test/java/org/jboss/logmanager/handlers/DelayedHandlerTests.java
+++ b/core/src/test/java/org/jboss/logmanager/handlers/DelayedHandlerTests.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import io.smallrye.common.cpu.ProcessorInfo;
 import org.jboss.logmanager.AssertingErrorManager;
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
@@ -37,7 +38,6 @@ import org.jboss.logmanager.LogContext;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-import org.wildfly.common.cpu.ProcessorInfo;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -65,8 +65,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.common</groupId>
-            <artifactId>wildfly-common</artifactId>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-constraint</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-expression</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/ext/src/main/java/org/jboss/logmanager/ext/PropertyConfigurator.java
+++ b/ext/src/main/java/org/jboss/logmanager/ext/PropertyConfigurator.java
@@ -34,13 +34,13 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import io.smallrye.common.constraint.Assert;
+import io.smallrye.common.expression.Expression;
 import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.StandardOutputStreams;
 import org.jboss.logmanager.ext.filters.FilterExpressions;
 import org.jboss.logmanager.filters.AcceptAllFilter;
 import org.jboss.logmanager.filters.DenyAllFilter;
-import org.wildfly.common.Assert;
-import org.wildfly.common.expression.Expression;
 
 /**
  * A utility to parse a {@code logging.properties} file and configure a {@link LogContext}.

--- a/ext/src/main/java/org/jboss/logmanager/ext/handlers/QueueHandler.java
+++ b/ext/src/main/java/org/jboss/logmanager/ext/handlers/QueueHandler.java
@@ -26,9 +26,9 @@ import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 
+import io.smallrye.common.constraint.Assert;
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
-import org.wildfly.common.Assert;
 
 /**
  * A queue handler which retains the last few messages logged.  The handler can be used as-is to remember recent

--- a/ext/src/main/java/org/jboss/logmanager/ext/handlers/SyslogHandler.java
+++ b/ext/src/main/java/org/jboss/logmanager/ext/handlers/SyslogHandler.java
@@ -43,7 +43,6 @@ import javax.net.ssl.SSLSocketFactory;
 
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
-import org.wildfly.common.os.Process;
 
 import static java.time.temporal.ChronoField.*;
 
@@ -471,7 +470,7 @@ public class SyslogHandler extends ExtHandler {
         this.serverAddress = serverAddress;
         this.port = port;
         this.facility = facility;
-        final long pid = Process.getProcessId();
+        final long pid = io.smallrye.common.os.Process.getProcessId();
         this.pid = (pid != -1 ? Long.toString(pid) : null);
         this.appName = "java";
         this.hostname = checkPrintableAscii("host name", hostname);

--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,13 @@
 
     <properties>
         <!-- Dependency versions -->
+        <version.io.smallrye.common.smallrye-common>1.11.0</version.io.smallrye.common.smallrye-common>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.org.byteman>4.0.17</version.org.byteman>
         <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
         <version.org.jboss.logging.jboss-logging>3.4.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.modules.jboss-modules>1.10.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.kohsuke.metainf-services>1.8</version.org.kohsuke.metainf-services>
-        <version.org.wildfly.common.wildfly-common>1.5.1.Final</version.org.wildfly.common.wildfly-common>
         <version.junit.junit>4.13.2</version.junit.junit>
 
         <!-- Test properties -->
@@ -98,9 +98,11 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.wildfly.common</groupId>
-                <artifactId>wildfly-common</artifactId>
-                <version>${version.org.wildfly.common.wildfly-common}</version>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-bom</artifactId>
+                <version>${version.io.smallrye.common.smallrye-common}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This is presently a draft because it would depend on https://github.com/smallrye/smallrye-common/pull/140.

~~Note that the `main` branch currently seems to be regressed~~ This was due to testing with Java 17, which the version of ByteMan in the POM does not support.