### PR TITLE
Copy marker field

### DIFF
--- a/core/src/main/java/org/jboss/logmanager/ExtLogRecord.java
+++ b/core/src/main/java/org/jboss/logmanager/ExtLogRecord.java
@@ -113,6 +113,7 @@ public class ExtLogRecord extends LogRecord {
             sourceModuleVersion = original.sourceModuleVersion;
         }
         formatStyle = original.formatStyle;
+        marker = original.marker;
         mdcCopy = original.mdcCopy;
         ndc = original.ndc;
         loggerClassName = original.loggerClassName;


### PR DESCRIPTION
This field is lost when we copy a log record.