### PR TITLE
Introduce module descriptors for all modules

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -74,6 +74,10 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.github.dmlloyd.module-info</groupId>
+                <artifactId>module-info</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/configuration/src/main/java/module-info.yml
+++ b/configuration/src/main/java/module-info.yml
@@ -1,0 +1,7 @@
+name: org.jboss.logmanager.configuration
+
+requires:
+  - module: io.smallrye.common.expression
+  - module: org.jboss.logmanager
+  - module: org.jboss.modules
+    static: true

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -164,6 +164,10 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.github.dmlloyd.module-info</groupId>
+                <artifactId>module-info</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/core/src/main/java/module-info.yml
+++ b/core/src/main/java/module-info.yml
@@ -1,0 +1,23 @@
+name: org.jboss.logmanager
+
+opens:
+  - package: org.jboss.logmanager.errormanager
+    to:
+      - org.jboss.logmanager.configuration
+  - package: org.jboss.logmanager.filters
+    to:
+      - org.jboss.logmanager.configuration
+  - package: org.jboss.logmanager.formatters
+    to:
+     - org.jboss.logmanager.configuration
+  - package: org.jboss.logmanager.handlers
+    to:
+     - org.jboss.logmanager.configuration
+
+requires:
+  - module: io.smallrye.common.constraint
+  - module: io.smallrye.common.net
+  - module: io.smallrye.common.os
+  - module: io.smallrye.common.ref
+  - module: org.jboss.modules
+    static: true

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -120,6 +120,10 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.github.dmlloyd.module-info</groupId>
+                <artifactId>module-info</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ext/src/main/java/module-info.yml
+++ b/ext/src/main/java/module-info.yml
@@ -1,0 +1,22 @@
+name: org.jboss.logmanager.ext
+
+opens:
+  - package: org.jboss.logmanager.ext.formatters
+    to:
+     - org.jboss.logmanager.configuration
+  - package: org.jboss.logmanager.ext.handlers
+    to:
+     - org.jboss.logmanager.configuration
+
+requires:
+  - module: io.smallrye.common.constraint
+
+  - module: jakarta.json-api
+    static: true
+
+  - module: org.jboss.logging
+
+  - module: org.jboss.logmanager
+
+  - module: org.jboss.modules
+    static: true

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,9 @@
         <org.jboss.test.port>4560</org.jboss.test.port>
         <org.jboss.test.alt.port>14560</org.jboss.test.alt.port>
 
+        <!-- Plugin versions -->
+        <version.io.github.dmlloyd.module-info>1.2</version.io.github.dmlloyd.module-info>
+
         <skipTests>false</skipTests>
         <skipITs>${skipTests}</skipITs>
         <skipUTs>${skipTests}</skipUTs>
@@ -179,6 +182,20 @@
                     <configuration>
                         <skipTests>${skipUTs}</skipTests>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>io.github.dmlloyd.module-info</groupId>
+                    <artifactId>module-info</artifactId>
+                    <version>${version.io.github.dmlloyd.module-info}</version>
+                    <executions>
+                        <execution>
+                            <id>module-info</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>generate</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
This draft PR introduces module descriptors for each submodule. There are several prerequisites to being able to merge this:

- [x] SmallRye Common release including `io.smallrye.common.ref` and module descriptors (any release after `2.0.0-RC2` should suffice)
- [x] SmallRye Common release including descriptor for `io.smallrye.common.net` (blocked on a JBoss Logging descriptor)
- [x] JBoss Modules release including a module descriptor (jboss-modules/jboss-modules#292, jboss-modules/jboss-modules#293)
- [x] JBoss Logging release including a module descriptor (jboss-logging/jboss-logging#45)
