### PR TITLE
LOGMGR-308 add client.jvm.jpms.args property for specifying JPMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <jdk.min.version>11</jdk.min.version>
+        <client.jvm.jpms.args></client.jvm.jpms.args>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -215,7 +216,7 @@
                     <includes>
                         <include>**/*Tests.java</include>
                     </includes>
-                    <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Djdk.attach.allowAttachSelf=true</argLine>
+                    <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Djdk.attach.allowAttachSelf=true ${client.jvm.jpms.args}</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
 


### PR DESCRIPTION
default JPMS properties. 

https://issues.redhat.com/projects/LOGMGR/issues/LOGMGR-308 