### PR TITLE
LOGMGR-315: SubstituteFilter is not applied to WrappedExtLogRecord

### DIFF
--- a/src/main/java/org/jboss/logmanager/WrappedExtLogRecord.java
+++ b/src/main/java/org/jboss/logmanager/WrappedExtLogRecord.java
@@ -157,6 +157,12 @@ class WrappedExtLogRecord extends ExtLogRecord {
         orig.setMessage(message);
     }
 
+    @Override
+    public void setMessage(String message, FormatStyle formatStyle) {
+        super.setMessage(message, formatStyle);
+        orig.setMessage(message);
+    }
+
     public Object[] getParameters() {
         return orig.getParameters();
     }

--- a/src/test/java/org/jboss/logmanager/FilterTests.java
+++ b/src/test/java/org/jboss/logmanager/FilterTests.java
@@ -507,6 +507,27 @@ public final class FilterTests {
         assertEquals("null", logRecord.getFormattedMessage());
     }
 
+    @Test
+    public void substitutionFilterWithLogRecord(){
+        final AtomicReference<String> result = new AtomicReference<String>();
+        final Handler handler = new MessageCheckingHandler(result);
+        final Logger logger = Logger.getLogger("filterTest");
+        final Filter filter = new SubstituteFilter(Pattern.compile("test"),"lunch",true);
+
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        logger.setLevel(Level.INFO);
+        logger.setFilter(filter);
+        handler.setLevel(Level.INFO);
+
+        final LogRecord record = new LogRecord(Level.INFO,"{0}");
+        record.setLoggerName("filterTest");
+        record.setParameters(new Object[]{"test"});
+
+        logger.log(record);
+        assertEquals("The substitution was not correctly applied","lunch",result.get());
+    }
+
 
 
     private static final class MessageCheckingHandler extends Handler {


### PR DESCRIPTION
o Initial implementation and test
o https://issues.redhat.com/browse/LOGMGR-315

Upstream #375 