### PR TITLE
Rework locking for Loom compatibility

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/FileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/FileHandler.java
@@ -125,8 +125,11 @@ public class FileHandler extends OutputStreamHandler {
      * @param append {@code true} to append, {@code false} to overwrite
      */
     public void setAppend(final boolean append) {
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.append = append;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -137,7 +140,8 @@ public class FileHandler extends OutputStreamHandler {
      * @throws FileNotFoundException if an error occurs opening the file
      */
     public void setFile(File file) throws FileNotFoundException {
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             if (file == null) {
                 this.file = null;
                 setOutputStream(null);
@@ -165,6 +169,8 @@ public class FileHandler extends OutputStreamHandler {
                     safeClose(fos);
                 }
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -174,8 +180,11 @@ public class FileHandler extends OutputStreamHandler {
      * @return the file
      */
     public File getFile() {
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             return file;
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/src/main/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandler.java
@@ -106,11 +106,14 @@ public class PeriodicRotatingFileHandler extends FileHandler {
 
     @Override
     public void setFile(final File file) throws FileNotFoundException {
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             super.setFile(file);
             if (format != null && file != null && file.lastModified() > 0) {
                 calcNextRollover(Instant.ofEpochMilli(file.lastModified()));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -160,7 +163,8 @@ public class PeriodicRotatingFileHandler extends FileHandler {
                 case 'S': throw new IllegalArgumentException("Rotating by second or millisecond is not supported");
             }
         }
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.format = format;
             this.period = period;
             this.suffixRotator = suffixRotator;
@@ -172,6 +176,8 @@ public class PeriodicRotatingFileHandler extends FileHandler {
                 now = Instant.now();
             }
             calcNextRollover(now);
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/src/main/java/org/jboss/logmanager/handlers/PeriodicSizeRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/PeriodicSizeRotatingFileHandler.java
@@ -140,9 +140,12 @@ public class PeriodicSizeRotatingFileHandler extends PeriodicRotatingFileHandler
 
     @Override
     public void setOutputStream(final OutputStream outputStream) {
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.outputStream = outputStream == null ? null : new CountingOutputStream(outputStream);
             super.setOutputStream(this.outputStream);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -154,7 +157,8 @@ public class PeriodicSizeRotatingFileHandler extends PeriodicRotatingFileHandler
     @Override
     public void setFile(final File file) throws FileNotFoundException {
         checkAccess();
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             // Check for a rotate
             if (rotateOnBoot && maxBackupIndex > 0 && file != null && file.exists() && file.length() > 0L) {
                 final String suffix = getNextSuffix();
@@ -166,6 +170,8 @@ public class PeriodicSizeRotatingFileHandler extends PeriodicRotatingFileHandler
                 }
             }
             setFileInternal(file, false);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -175,8 +181,11 @@ public class PeriodicSizeRotatingFileHandler extends PeriodicRotatingFileHandler
      * @return {@code true} if file should rotate on boot, otherwise {@code false}/
      */
     public boolean isRotateOnBoot() {
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             return rotateOnBoot;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -188,8 +197,11 @@ public class PeriodicSizeRotatingFileHandler extends PeriodicRotatingFileHandler
      */
     public void setRotateOnBoot(final boolean rotateOnBoot) {
         checkAccess();
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.rotateOnBoot = rotateOnBoot;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -200,8 +212,11 @@ public class PeriodicSizeRotatingFileHandler extends PeriodicRotatingFileHandler
      */
     public void setRotateSize(final long rotateSize) {
         checkAccess();
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.rotateSize = rotateSize;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -212,8 +227,11 @@ public class PeriodicSizeRotatingFileHandler extends PeriodicRotatingFileHandler
      */
     public void setMaxBackupIndex(final int maxBackupIndex) {
         checkAccess();
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.maxBackupIndex = maxBackupIndex;
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/src/main/java/org/jboss/logmanager/handlers/SizeRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/SizeRotatingFileHandler.java
@@ -129,9 +129,12 @@ public class SizeRotatingFileHandler extends FileHandler {
 
     /** {@inheritDoc} */
     public void setOutputStream(final OutputStream outputStream) {
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.outputStream = outputStream == null ? null : new CountingOutputStream(outputStream);
             super.setOutputStream(this.outputStream);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -142,7 +145,8 @@ public class SizeRotatingFileHandler extends FileHandler {
      */
     public void setFile(final File file) throws FileNotFoundException {
         checkAccess();
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             // Check for a rotate
             if (rotateOnBoot && maxBackupIndex > 0 && file != null && file.exists() && file.length() > 0L) {
                 // Make sure any previous files are closed before we attempt to rotate
@@ -150,6 +154,8 @@ public class SizeRotatingFileHandler extends FileHandler {
                 suffixRotator.rotate(getErrorManager(), file.toPath(), maxBackupIndex);
             }
             setFileInternal(file, false);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -159,8 +165,11 @@ public class SizeRotatingFileHandler extends FileHandler {
      * @return {@code true} if file should rotate on boot, otherwise {@code false}/
      */
     public boolean isRotateOnBoot() {
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             return rotateOnBoot;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -172,8 +181,11 @@ public class SizeRotatingFileHandler extends FileHandler {
      */
     public void setRotateOnBoot(final boolean rotateOnBoot) {
         checkAccess();
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.rotateOnBoot = rotateOnBoot;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -184,8 +196,11 @@ public class SizeRotatingFileHandler extends FileHandler {
      */
     public void setRotateSize(final long rotateSize) {
         checkAccess();
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.rotateSize = rotateSize;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -196,8 +211,11 @@ public class SizeRotatingFileHandler extends FileHandler {
      */
     public void setMaxBackupIndex(final int maxBackupIndex) {
         checkAccess();
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.maxBackupIndex = maxBackupIndex;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -233,8 +251,11 @@ public class SizeRotatingFileHandler extends FileHandler {
      */
     public void setSuffix(final String suffix) {
         checkAccess();
-        synchronized (outputLock) {
+        lock.lock();
+        try {
             this.suffixRotator = SuffixRotator.parse(acc, suffix);
+        } finally {
+            lock.unlock();
         }
     }
 


### PR DESCRIPTION
* Change `synchronized` constructs that cover blocking code to use a shared (per-instance) `ReentrantLock`
* Unify discrete locks among `ExtHandler` subclasses
* Remove `protected` `outputLock` object which was used for synchronization among subclasses of `WriterHandler` and replace with shared `lock`
* Protect `setCharset` with lock to retain behavior of `java.util.logging.Handler`
* Shadow private fields from `j.u.l.Handler` which are protected by `synchronized` in that class
* Replace tree lock with `ReentrantLock`

This is technically a compatibility-impacting change (and thus should not be backported) since the `protected` `outputLock` field has been removed from `WriterHandler` and not replaced. The new lock field is called `lock` and it is on `ExtHandler` itself. The new field must have a distinct name from the old field, otherwise existing third-party code which tries to `synchronize` on the lock field will lock on the `ReentrantLock`'s monitor, not the `ReentrantLock` itself.

Another behavioral change is that the handler tree previously had a few locks (three or four), with subclass hierarchies often maintaining their own lock. I don't expect this to be a problem (if anything I expect to avoid possible deadlock scenarios) but it is worth mentioning.

In one case a different lock was used to read and write a non-`volatile` field on a handler which was a source of possible obscure bugs; this has been fixed to use the common `lock`.

Related to openjdk/jdk#13832. Depends on #378.