### PR TITLE
Add support for graphical banners

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/OutputStreamHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/OutputStreamHandler.java
@@ -138,6 +138,11 @@ public class OutputStreamHandler extends WriterHandler {
         }
     }
 
+    OutputStream getOutputStream() {
+        assert lock.isHeldByCurrentThread();
+        return outputStream;
+    }
+
     private Writer getNewWriter(OutputStream newOutputStream) {
         if (newOutputStream == null) return null;
         final UninterruptibleOutputStream outputStream = new UninterruptibleOutputStream(new UncloseableOutputStream(newOutputStream));

--- a/src/main/java/org/jboss/logmanager/handlers/WriterHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/WriterHandler.java
@@ -125,6 +125,11 @@ public class WriterHandler extends ExtHandler {
         }
     }
 
+    Writer getWriter() {
+        assert lock.isHeldByCurrentThread();
+        return writer;
+    }
+
     /**
      * Determine whether head encoding checking is turned on.
      *


### PR DESCRIPTION
Add the ability to write a graphical banner (in PNG format) to the terminal, if the console is detected to support graphics. The image is streamed from a given input stream. Optional values can be given to specify how many character cells (width and height) should be occupied by the image.

Note that this is very hard to unit test. :-) I did test it in my terminal with a test program and the Quarkus banner.