### PR TITLE
[LOGMGR-324] Let initializer enable strong node refs

### DIFF
--- a/src/main/java/org/jboss/logmanager/LogContext.java
+++ b/src/main/java/org/jboss/logmanager/LogContext.java
@@ -140,8 +140,8 @@ public final class LogContext implements AutoCloseable {
     final ReentrantLock treeLock = new ReentrantLock();
 
     LogContext(final boolean strong, LogContextInitializer initializer) {
-        this.strong = strong;
         this.initializer = initializer;
+        this.strong = strong || initializer.useStrongReferences();
         levelMapReference = new AtomicReference<Map<String, Reference<Level, Void>>>(LazyHolder.INITIAL_LEVEL_MAP);
         rootLogger = new LoggerNode(this);
         closeHandlers = new LinkedHashSet<>();

--- a/src/main/java/org/jboss/logmanager/LogContextInitializer.java
+++ b/src/main/java/org/jboss/logmanager/LogContextInitializer.java
@@ -82,4 +82,13 @@ public interface LogContextInitializer {
     default Handler[] getInitialHandlers(String loggerName) {
         return NO_HANDLERS;
     }
+
+    /**
+     * Establish whether strong references should be used for logger nodes.
+     *
+     * @return {@code true} to use strong references, or {@code false} to use weak references
+     */
+    default boolean useStrongReferences() {
+        return false;
+    }
 }


### PR DESCRIPTION
Quarkus uses only strong refs in the logger node tree.