### PR TITLE
Introduce extra indirection in `ObjectBuilder$ModuleFinder`

### DIFF
--- a/src/main/java/org/jboss/logmanager/configuration/ObjectBuilder.java
+++ b/src/main/java/org/jboss/logmanager/configuration/ObjectBuilder.java
@@ -371,11 +371,18 @@ class ObjectBuilder<T> {
         }
 
         static ClassLoader getClassLoader(final String moduleName) throws Exception {
-            ModuleLoader moduleLoader = ModuleLoader.forClass(ModuleFinder.class);
-            if (moduleLoader == null) {
-                moduleLoader = Module.getBootModuleLoader();
+            return Holder.getClassLoader(moduleName);
+        }
+
+        private static class Holder {
+
+            static ClassLoader getClassLoader(final String moduleName) throws Exception {
+                ModuleLoader moduleLoader = ModuleLoader.forClass(ModuleFinder.class);
+                if (moduleLoader == null) {
+                    moduleLoader = Module.getBootModuleLoader();
+                }
+                return moduleLoader.loadModule(moduleName).getClassLoader();
             }
-            return moduleLoader.loadModule(moduleName).getClassLoader();
         }
     }
 


### PR DESCRIPTION
The reason this is done is to allow
`ObjectBuilder$ModuleFinder` the class to be
loaded and initialized even when JBoss Modules
is not present on the classpath.
The ultimate goal of this is to allow for Quarkus
to substitute the method when building a native
image and fix the problem mentioned in
https://github.com/quarkusio/quarkus/pull/33318#issuecomment-1668008546