### PR TITLE
Do not compress the JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,20 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Do not compress JAR, for faster startup times -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <compress>false</compress>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Do not compress the class files in the artifact JAR.

This change increases the size-on-disk of the JBoss LogManager JAR from around 363K to around 781K.  In return, the expectation is that class loading time, and thus startup time, would be measurably improved, due to not involving `java.util.zip.Inflater` which has a fairly significant overhead. Instead the bytes of the class can be loaded directly from the zip file.

This change is not expected to increase in-memory size in any way in the case of the standard class loaders, since the JDK does not normally retain the compressed class file in memory (it would either retain the entire uncompressed class, some part of the uncompressed class, or none of the class at all, in any which case the status quo would remain unchanged).

Advanced class loaders which map JARs into memory might see a difference in RSS depending on how the OS or container might account for such things.  However such class loaders would be able to benefit even more from not having to decompress the archive, since they can then potentially use zero-copy strategies to define classes from class file bytes.  Most such class loading systems would not be able to load this particular project due to its usage in early bootstrap.

Opened as a draft to make this available for testing and experimentation.