### PR TITLE
Use day of month instead of day of year in default format string

### DIFF
--- a/src/main/java/org/jboss/logmanager/formatters/Formatters.java
+++ b/src/main/java/org/jboss/logmanager/formatters/Formatters.java
@@ -478,7 +478,7 @@ public final class Formatters {
             final boolean truncateBeginning, final int maximumWidth) {
         return new JustifyingFormatStep(leftJustify, minimumWidth, truncateBeginning, maximumWidth) {
             final DateTimeFormatter dtf = DateTimeFormatter
-                    .ofPattern(formatString == null ? "yyyy-MM-DD HH:mm:ss,SSS" : formatString);
+                    .ofPattern(formatString == null ? "yyyy-MM-dd HH:mm:ss,SSS" : formatString);
 
             public ItemType getItemType() {
                 return ItemType.DATE;


### PR DESCRIPTION
I'm using Quarkus which uses this library and I noticed the default %d (i.e. date string) log symbol now resolves to a different pattern.

DD is day of year and dd is day of month. 

Apologies if my commit/PR isn't up to scratch (I'm not sure if I set this account up correctly).