### PR TITLE
[LOGMGR-342] Properly detect console charset

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,18 +23,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: ['11', '17']
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Set up JDKs
         uses: actions/setup-java@v3
         with:
-          java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
-      - name: Build and Test with Java ${{ matrix.java }}
-        run: mvn -B clean verify
+          java-version: |
+              11
+              17
+              21
+      - name: Build and Test
+        run: mvn -B clean verify "-Djava11.home=${{env.JAVA_HOME_11_X64}}" "-Djava17.home=${{env.JAVA_HOME_17_X64}}"
 
   format-check:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.jboss.logging</groupId>
         <artifactId>logging-parent</artifactId>
-        <version>1.0.1.Final</version>
+        <version>1.0.2.Final</version>
     </parent>
 
     <name>JBoss Log Manager</name>
@@ -54,7 +54,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <version.io.smallrye.common.smallrye-common>2.1.0</version.io.smallrye.common.smallrye-common>
+        <version.io.smallrye.common.smallrye-common>2.2.0</version.io.smallrye.common.smallrye-common>
         <version.jakarta.json.jakarta-json-api>2.1.2</version.jakarta.json.jakarta-json-api>
         <version.org.byteman>4.0.21</version.org.byteman>
         <version.org.eclipse.parsson.jakarta.json>1.1.4</version.org.eclipse.parsson.jakarta.json>
@@ -75,6 +75,9 @@
         <skipUTs>${skipTests}</skipUTs>
 
         <client.jvm.jpms.args></client.jvm.jpms.args>
+
+        <!-- JDK configuration: require Java 17 to build -->
+        <jdk.min.version>17</jdk.min.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -170,6 +173,15 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <!-- TODO: remove if we stop using logging-parent -->
+                            <release>11</release>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
@@ -201,12 +213,19 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                    </execution>
+                </executions>
                 <configuration>
+                    <!-- TODO: module path mode currently won't load optional modules -->
+                    <useModulePath>false</useModulePath>
                     <skipTests>${skipUTs}</skipTests>
                     <includes>
                         <include>**/*Tests.java</include>
                     </includes>
-                    <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager --add-modules=org.eclipse.parsson -Djdk.attach.allowAttachSelf=true ${client.jvm.jpms.args}</argLine>
+                    <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Djdk.attach.allowAttachSelf=true ${client.jvm.jpms.args}</argLine>
                     <reuseForks>false</reuseForks>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/src/main/java/org/jboss/logmanager/handlers/ConsoleHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/ConsoleHandler.java
@@ -102,6 +102,7 @@ public class ConsoleHandler extends OutputStreamHandler {
      */
     public ConsoleHandler(final Target target, final Formatter formatter) {
         super(formatter);
+        setCharset(JDKSpecific.consoleCharset());
         switch (target) {
             case SYSTEM_OUT:
                 setOutputStream(wrap(out));

--- a/src/main/java/org/jboss/logmanager/handlers/JDKSpecific.java
+++ b/src/main/java/org/jboss/logmanager/handlers/JDKSpecific.java
@@ -1,0 +1,31 @@
+package org.jboss.logmanager.handlers;
+
+import java.io.Console;
+import java.nio.charset.Charset;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * JDK-specific code relating to {@link Console}.
+ */
+final class JDKSpecific {
+    private JDKSpecific() {
+    }
+
+    private static final Charset CONSOLE_CHARSET;
+
+    static {
+        // Make various guesses as to what the encoding of the console is
+        String encodingName = AccessController
+                .doPrivileged((PrivilegedAction<String>) () -> System.getProperty("stdout.encoding"));
+        if (encodingName == null) {
+            encodingName = AccessController
+                    .doPrivileged((PrivilegedAction<String>) () -> System.getProperty("native.encoding"));
+        }
+        CONSOLE_CHARSET = encodingName == null ? Charset.defaultCharset() : Charset.forName(encodingName);
+    }
+
+    static Charset consoleCharset() {
+        return CONSOLE_CHARSET;
+    }
+}

--- a/src/main/java17/org/jboss/logmanager/handlers/JDKSpecific.java
+++ b/src/main/java17/org/jboss/logmanager/handlers/JDKSpecific.java
@@ -1,0 +1,35 @@
+package org.jboss.logmanager.handlers;
+
+import java.io.Console;
+import java.nio.charset.Charset;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * JDK-specific code relating to {@link Console}.
+ */
+final class JDKSpecific {
+    private JDKSpecific() {}
+
+    private static final Charset CONSOLE_CHARSET;
+
+    static {
+        Console console = System.console();
+        Charset charset;
+        if (console != null) {
+            charset = console.charset();
+        } else {
+            // Make various guesses as to what the encoding of the console is
+            String encodingName = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("stdout.encoding"));
+            if (encodingName == null) {
+                encodingName = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("native.encoding"));
+            }
+            charset = encodingName == null ? Charset.defaultCharset() : Charset.forName(encodingName);
+        }
+        CONSOLE_CHARSET = charset;
+    }
+
+    static Charset consoleCharset() {
+        return CONSOLE_CHARSET;
+    }
+}


### PR DESCRIPTION
This requires an MR JAR to support both JDK 11 and 17+. As such, a number of changes to the build are needed due to problems with the surefire plugin.