### PR TITLE
[LOGMGR-343] If the AsyncHandler's worker thread and the current thread are the same, do not add the record the queue

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/AsyncHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/AsyncHandler.java
@@ -146,6 +146,10 @@ public class AsyncHandler extends ExtHandler {
             // Copy the MDC over
             record.copyMdc();
         }
+        if (Thread.currentThread() == thread) {
+            publishToNestedHandlers(record);
+            return;
+        }
         if (overflowAction == OverflowAction.DISCARD) {
             recordQueue.offer(record);
         } else {


### PR DESCRIPTION
https://issues.redhat.com/browse/LOGMGR-343