### PR TITLE
Add support for long thread IDs

### DIFF
--- a/src/main/java/org/jboss/logmanager/formatters/Formatters.java
+++ b/src/main/java/org/jboss/logmanager/formatters/Formatters.java
@@ -1202,7 +1202,7 @@ public final class Formatters {
             }
 
             public void renderRaw(Formatter formatter, final StringBuilder builder, final ExtLogRecord record) {
-                builder.append(record.getThreadID());
+                builder.append(record.getLongThreadID());
             }
         };
     }


### PR DESCRIPTION
An idea for supporting long thread IDs before we have a requirement for Java 17. Avoids MR-JAR complexities by instead relying on `MethodHandle` complexities.