### PR TITLE
[LOGMGR-343] If the AsyncHandler's worker thread and the current thre…

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/AsyncHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/AsyncHandler.java
@@ -148,6 +148,13 @@ public class AsyncHandler extends ExtHandler {
             // In case serialization is required by a child handler
             record.getFormattedMessage();
         }
+        if (Thread.currentThread() == thread) {
+            final Handler[] handlers = this.handlers;
+            for (Handler handler : handlers) {
+                handler.publish(record);
+            }
+            return;
+        }
         if (overflowAction == OverflowAction.DISCARD) {
             recordQueue.offer(record);
         } else {


### PR DESCRIPTION
…ad are the same, do not add the record the queue. Simply delegate the record down to the nested handlers.

https://issues.redhat.com/browse/LOGMGR-343