### PR TITLE
Pluggable stack trace formatting

### DIFF
--- a/src/main/java/org/jboss/logmanager/formatters/BasicStackTraceFormatter.java
+++ b/src/main/java/org/jboss/logmanager/formatters/BasicStackTraceFormatter.java
@@ -1,0 +1,162 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager.formatters;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+/**
+ * Formatter used to format the stack trace of an exception.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+final class BasicStackTraceFormatter {
+    private static final String CAUSED_BY_CAPTION = "Caused by: ";
+    private static final String SUPPRESSED_CAPTION = "Suppressed: ";
+
+    private final Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<Throwable, Boolean>());
+    private final StringBuilder builder;
+    private final int suppressedDepth;
+    private int suppressedCount;
+
+    private BasicStackTraceFormatter(final StringBuilder builder, final int suppressedDepth) {
+        this.builder = builder;
+        this.suppressedDepth = suppressedDepth;
+    }
+
+    /**
+     * Writes the stack trace into the builder.
+     *
+     * @param builder         the string builder ot append the stack trace to
+     * @param t               the throwable to render
+     * @param suppressedDepth the number of suppressed messages to include
+     */
+    public static void renderStackTrace(final StringBuilder builder, final Throwable t, final int suppressedDepth) {
+        renderStackTrace(builder, t, false, suppressedDepth);
+    }
+
+    /**
+     * Writes the stack trace into the builder.
+     *
+     * @param builder         the string builder ot append the stack trace to
+     * @param t               the throwable to render
+     * @param extended        ignored
+     * @param suppressedDepth the number of suppressed messages to include
+     */
+    static void renderStackTrace(final StringBuilder builder, final Throwable t,
+            @SuppressWarnings("unused") final boolean extended, final int suppressedDepth) {
+        new BasicStackTraceFormatter(builder, suppressedDepth).renderStackTrace(t);
+    }
+
+    private void renderStackTrace(final Throwable t) {
+        // Reset the suppression count
+        suppressedCount = 0;
+        // Write the exception message
+        builder.append(": ").append(t);
+        newLine();
+
+        // Write the stack trace for this message
+        final StackTraceElement[] stackTrace = t.getStackTrace();
+        for (StackTraceElement element : stackTrace) {
+            renderTrivial("", element);
+        }
+
+        // Write any suppressed messages, if required
+        if (suppressedDepth != 0) {
+            for (Throwable se : t.getSuppressed()) {
+                if (suppressedDepth < 0 || suppressedDepth > suppressedCount++) {
+                    renderStackTrace(stackTrace, se, SUPPRESSED_CAPTION, "\t");
+                }
+            }
+        }
+
+        // Print cause if there is one
+        final Throwable ourCause = t.getCause();
+        if (ourCause != null) {
+            renderStackTrace(stackTrace, ourCause, CAUSED_BY_CAPTION, "");
+        }
+    }
+
+    private void renderStackTrace(final StackTraceElement[] parentStack, final Throwable child, final String caption,
+            final String prefix) {
+        if (seen.contains(child)) {
+            builder.append(prefix)
+                    .append(caption)
+                    .append("[CIRCULAR REFERENCE: ")
+                    .append(child)
+                    .append(']');
+            newLine();
+        } else {
+            seen.add(child);
+            // Find the unique frames suppressing duplicates
+            final StackTraceElement[] causeStack = child.getStackTrace();
+            int m = causeStack.length - 1;
+            int n = parentStack.length - 1;
+            while (m >= 0 && n >= 0 && causeStack[m].equals(parentStack[n])) {
+                m--;
+                n--;
+            }
+            final int framesInCommon = causeStack.length - 1 - m;
+
+            // Print our stack trace
+            builder.append(prefix)
+                    .append(caption)
+                    .append(child);
+            newLine();
+            for (int i = 0; i <= m; i++) {
+                renderTrivial(prefix, causeStack[i]);
+            }
+            if (framesInCommon != 0) {
+                builder.append(prefix)
+                        .append("\t... ")
+                        .append(framesInCommon)
+                        .append(" more");
+                newLine();
+            }
+
+            // Print suppressed exceptions, if any
+            if (suppressedDepth != 0) {
+                for (Throwable se : child.getSuppressed()) {
+                    if (suppressedDepth < 0 || suppressedDepth > suppressedCount++) {
+                        renderStackTrace(causeStack, se, SUPPRESSED_CAPTION, prefix + "\t");
+                    }
+                }
+            }
+
+            // Print cause, if any
+            Throwable ourCause = child.getCause();
+            if (ourCause != null) {
+                renderStackTrace(causeStack, ourCause, CAUSED_BY_CAPTION, prefix);
+            }
+        }
+    }
+
+    private void renderTrivial(final String prefix, final StackTraceElement element) {
+        builder.append(prefix)
+                .append("\tat ")
+                .append(element);
+        newLine();
+    }
+
+    private void newLine() {
+        builder.append(System.lineSeparator());
+    }
+}

--- a/src/main/java/org/jboss/logmanager/formatters/StackTraceFormatter.java
+++ b/src/main/java/org/jboss/logmanager/formatters/StackTraceFormatter.java
@@ -1,162 +1,50 @@
-/*
- * JBoss, Home of Professional Open Source.
- *
- * Copyright 2017 Red Hat, Inc., and individual contributors
- * as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.jboss.logmanager.formatters;
 
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.Set;
+import java.io.IOException;
+import java.util.ServiceLoader;
 
 /**
- * Formatter used to format the stack trace of an exception.
- *
- * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ * A stack trace formatter.
+ * An implementation of this interface is located using {@link ServiceLoader} to determine how to format
+ * stack traces.
  */
-public class StackTraceFormatter {
-    private static final String CAUSED_BY_CAPTION = "Caused by: ";
-    private static final String SUPPRESSED_CAPTION = "Suppressed: ";
+public interface StackTraceFormatter {
+    /**
+     * Render an exception stack trace to the given output.
+     *
+     * @param t          the root exception (not {@code null})
+     * @param output     the output to which the exception stack trace should be written (not {@code null})
+     * @param parameters the format parameters (not {@code null})
+     */
+    void render(Throwable t, Appendable output, Parameters parameters) throws IOException;
 
-    private final Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<Throwable, Boolean>());
-    private final StringBuilder builder;
-    private final int suppressedDepth;
-    private int suppressedCount;
+    /**
+     * Parameters for a stack trace formatting request.
+     */
+    interface Parameters {
+        /**
+         * {@return <code>true</code> if the "extended" hint is given, or <code>false</code> otherwise}
+         * Implementations may ignore this parameter; it is only a hint.
+         */
+        default boolean extended() {
+            return false;
+        }
 
-    private StackTraceFormatter(final StringBuilder builder, final int suppressedDepth) {
-        this.builder = builder;
-        this.suppressedDepth = suppressedDepth;
+        /**
+         * {@return the maximum depth of nested or suppressed exceptions to render}
+         * Implementations may ignore this parameter; it is only a hint.
+         */
+        default int suppressedDepth() {
+            return Integer.MAX_VALUE;
+        }
     }
 
     /**
-     * Writes the stack trace into the builder.
+     * Get the singleton stack trace formatter instance.
      *
-     * @param builder         the string builder ot append the stack trace to
-     * @param t               the throwable to render
-     * @param suppressedDepth the number of suppressed messages to include
+     * @return the stack trace formatter instance (not {@code null})
      */
-    public static void renderStackTrace(final StringBuilder builder, final Throwable t, final int suppressedDepth) {
-        renderStackTrace(builder, t, false, suppressedDepth);
-    }
-
-    /**
-     * Writes the stack trace into the builder.
-     *
-     * @param builder         the string builder ot append the stack trace to
-     * @param t               the throwable to render
-     * @param extended        ignored
-     * @param suppressedDepth the number of suppressed messages to include
-     */
-    static void renderStackTrace(final StringBuilder builder, final Throwable t,
-            @SuppressWarnings("unused") final boolean extended, final int suppressedDepth) {
-        new StackTraceFormatter(builder, suppressedDepth).renderStackTrace(t);
-    }
-
-    private void renderStackTrace(final Throwable t) {
-        // Reset the suppression count
-        suppressedCount = 0;
-        // Write the exception message
-        builder.append(": ").append(t);
-        newLine();
-
-        // Write the stack trace for this message
-        final StackTraceElement[] stackTrace = t.getStackTrace();
-        for (StackTraceElement element : stackTrace) {
-            renderTrivial("", element);
-        }
-
-        // Write any suppressed messages, if required
-        if (suppressedDepth != 0) {
-            for (Throwable se : t.getSuppressed()) {
-                if (suppressedDepth < 0 || suppressedDepth > suppressedCount++) {
-                    renderStackTrace(stackTrace, se, SUPPRESSED_CAPTION, "\t");
-                }
-            }
-        }
-
-        // Print cause if there is one
-        final Throwable ourCause = t.getCause();
-        if (ourCause != null) {
-            renderStackTrace(stackTrace, ourCause, CAUSED_BY_CAPTION, "");
-        }
-    }
-
-    private void renderStackTrace(final StackTraceElement[] parentStack, final Throwable child, final String caption,
-            final String prefix) {
-        if (seen.contains(child)) {
-            builder.append(prefix)
-                    .append(caption)
-                    .append("[CIRCULAR REFERENCE: ")
-                    .append(child)
-                    .append(']');
-            newLine();
-        } else {
-            seen.add(child);
-            // Find the unique frames suppressing duplicates
-            final StackTraceElement[] causeStack = child.getStackTrace();
-            int m = causeStack.length - 1;
-            int n = parentStack.length - 1;
-            while (m >= 0 && n >= 0 && causeStack[m].equals(parentStack[n])) {
-                m--;
-                n--;
-            }
-            final int framesInCommon = causeStack.length - 1 - m;
-
-            // Print our stack trace
-            builder.append(prefix)
-                    .append(caption)
-                    .append(child);
-            newLine();
-            for (int i = 0; i <= m; i++) {
-                renderTrivial(prefix, causeStack[i]);
-            }
-            if (framesInCommon != 0) {
-                builder.append(prefix)
-                        .append("\t... ")
-                        .append(framesInCommon)
-                        .append(" more");
-                newLine();
-            }
-
-            // Print suppressed exceptions, if any
-            if (suppressedDepth != 0) {
-                for (Throwable se : child.getSuppressed()) {
-                    if (suppressedDepth < 0 || suppressedDepth > suppressedCount++) {
-                        renderStackTrace(causeStack, se, SUPPRESSED_CAPTION, prefix + "\t");
-                    }
-                }
-            }
-
-            // Print cause, if any
-            Throwable ourCause = child.getCause();
-            if (ourCause != null) {
-                renderStackTrace(causeStack, ourCause, CAUSED_BY_CAPTION, prefix);
-            }
-        }
-    }
-
-    private void renderTrivial(final String prefix, final StackTraceElement element) {
-        builder.append(prefix)
-                .append("\tat ")
-                .append(element);
-        newLine();
-    }
-
-    private void newLine() {
-        builder.append(System.lineSeparator());
+    static StackTraceFormatter instance() {
+        return StackTraceFormatterHolder.INSTANCE;
     }
 }

--- a/src/main/java/org/jboss/logmanager/formatters/StackTraceFormatterHolder.java
+++ b/src/main/java/org/jboss/logmanager/formatters/StackTraceFormatterHolder.java
@@ -1,0 +1,68 @@
+package org.jboss.logmanager.formatters;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+
+/**
+ *
+ */
+final class StackTraceFormatterHolder {
+    private StackTraceFormatterHolder() {
+    }
+
+    static final StackTraceFormatter INSTANCE;
+
+    static {
+        StackTraceFormatter instance = null;
+        // we can't use service loader here, because of course it logs, causing things to fail weirdly.
+        // so, do our own thing
+        try {
+            ClassLoader cl = StackTraceFormatterHolder.class.getClassLoader();
+            Enumeration<URL> e = cl.getResources("META-INF/services/" + StackTraceFormatter.class.getName());
+            out: while (e.hasMoreElements()) {
+                try {
+                    URL url = e.nextElement();
+                    try (InputStream is = url.openStream();
+                            InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+                            BufferedReader br = new BufferedReader(isr)) {
+                        String line;
+                        while ((line = br.readLine()) != null) {
+                            int idx = line.indexOf('#');
+                            if (idx != -1) {
+                                line = line.substring(idx);
+                            }
+                            line = line.trim();
+                            if (!line.isBlank()) {
+                                try {
+                                    Class<? extends StackTraceFormatter> stfClass = Class.forName(line, false, cl)
+                                            .asSubclass(StackTraceFormatter.class);
+                                    MethodHandle ctor = MethodHandles.publicLookup().findConstructor(stfClass,
+                                            MethodType.methodType(void.class));
+                                    instance = (StackTraceFormatter) ctor.invoke();
+                                    break out;
+                                } catch (Throwable ignored) {
+                                    // just try the next line
+                                }
+                            }
+                        }
+                    }
+                } catch (Throwable ignored) {
+                    // try the next file
+                }
+            }
+        } catch (Throwable ignored) {
+            // can't get the resources at all; give up
+        }
+        if (instance == null) {
+            instance = StackTraceFormatterImpl.INSTANCE;
+        }
+        INSTANCE = instance;
+    }
+}

--- a/src/main/java/org/jboss/logmanager/formatters/StackTraceFormatterImpl.java
+++ b/src/main/java/org/jboss/logmanager/formatters/StackTraceFormatterImpl.java
@@ -1,0 +1,28 @@
+package org.jboss.logmanager.formatters;
+
+import java.io.IOException;
+
+/**
+ * The default implementation of {@link StackTraceFormatter}.
+ */
+final class StackTraceFormatterImpl implements StackTraceFormatter {
+    /**
+     * Construct a new instance.
+     */
+    private StackTraceFormatterImpl() {
+    }
+
+    static final StackTraceFormatterImpl INSTANCE = new StackTraceFormatterImpl();
+
+    public void render(final Throwable t, final Appendable output, final Parameters parameters) throws IOException {
+        StringBuilder sb;
+        if (output instanceof StringBuilder) {
+            sb = (StringBuilder) output;
+            BasicStackTraceFormatter.renderStackTrace(sb, t, parameters.suppressedDepth());
+        } else {
+            sb = new StringBuilder();
+            BasicStackTraceFormatter.renderStackTrace(sb, t, parameters.suppressedDepth());
+            output.append(sb);
+        }
+    }
+}

--- a/src/main/java/org/jboss/logmanager/formatters/StructuredFormatter.java
+++ b/src/main/java/org/jboss/logmanager/formatters/StructuredFormatter.java
@@ -245,7 +245,7 @@ public abstract class StructuredFormatter extends ExtFormatter {
 
                 if (isFormattedExceptionOutputType()) {
                     final StringBuilder sb = new StringBuilder();
-                    StackTraceFormatter.renderStackTrace(sb, thrown, -1);
+                    BasicStackTraceFormatter.renderStackTrace(sb, thrown, -1);
                     generator.add(getKey(Key.STACK_TRACE), sb.toString());
                 }
             }

--- a/src/test/java/org/jboss/logmanager/formatters/StackTraceFormatterTests.java
+++ b/src/test/java/org/jboss/logmanager/formatters/StackTraceFormatterTests.java
@@ -40,7 +40,7 @@ public class StackTraceFormatterTests {
         e.printStackTrace(new PrintWriter(writer));
 
         final StringBuilder sb = new StringBuilder();
-        StackTraceFormatter.renderStackTrace(sb, e, false, -1);
+        BasicStackTraceFormatter.renderStackTrace(sb, e, false, -1);
 
         Assertions.assertEquals(writer.toString(), sanitize(sb.toString()));
     }
@@ -53,7 +53,7 @@ public class StackTraceFormatterTests {
         e.printStackTrace(new PrintWriter(writer));
 
         final StringBuilder sb = new StringBuilder();
-        StackTraceFormatter.renderStackTrace(sb, e, false, -1);
+        BasicStackTraceFormatter.renderStackTrace(sb, e, false, -1);
 
         Assertions.assertEquals(writer.toString(), sanitize(sb.toString()));
     }
@@ -73,7 +73,7 @@ public class StackTraceFormatterTests {
         cause.printStackTrace(new PrintWriter(writer));
 
         final StringBuilder sb = new StringBuilder();
-        StackTraceFormatter.renderStackTrace(sb, cause, false, -1);
+        BasicStackTraceFormatter.renderStackTrace(sb, cause, false, -1);
 
         Assertions.assertEquals(writer.toString(), sanitize(sb.toString()));
     }
@@ -97,7 +97,7 @@ public class StackTraceFormatterTests {
         cause.printStackTrace(new PrintWriter(writer));
 
         final StringBuilder sb = new StringBuilder();
-        StackTraceFormatter.renderStackTrace(sb, cause, false, -1);
+        BasicStackTraceFormatter.renderStackTrace(sb, cause, false, -1);
 
         Assertions.assertEquals(writer.toString(), sanitize(sb.toString()));
     }
@@ -111,7 +111,7 @@ public class StackTraceFormatterTests {
         cause.printStackTrace(new PrintWriter(writer));
 
         final StringBuilder sb = new StringBuilder();
-        StackTraceFormatter.renderStackTrace(sb, cause, false, -1);
+        BasicStackTraceFormatter.renderStackTrace(sb, cause, false, -1);
 
         Assertions.assertEquals(writer.toString(), sanitize(sb.toString()));
     }
@@ -126,7 +126,7 @@ public class StackTraceFormatterTests {
         cause.printStackTrace(new PrintWriter(writer));
 
         final StringBuilder sb = new StringBuilder();
-        StackTraceFormatter.renderStackTrace(sb, cause, false, -1);
+        BasicStackTraceFormatter.renderStackTrace(sb, cause, false, -1);
 
         Assertions.assertEquals(writer.toString(), sanitize(sb.toString()));
     }
@@ -145,7 +145,7 @@ public class StackTraceFormatterTests {
         final Throwable cause = createMultiNestedCause();
 
         final StringBuilder sb = new StringBuilder();
-        StackTraceFormatter.renderStackTrace(sb, cause, false, depth);
+        BasicStackTraceFormatter.renderStackTrace(sb, cause, false, depth);
 
         String msg = sb.toString();
 


### PR DESCRIPTION
This is a potential approach to allow a pluggable stack trace formatter.

Note a couple of important points:
* Service loader cannot be used at this early stage of bootstrap. It doesn't overtly fail with an exception, but certain things fail to initialize in the right order randomly resulting in sporadic and hard-to debug unit test failures. Idea: introduce a private logmanager-safe service loader, if we want more things to be pluggable?
* There is only one global stack trace formatter. It might be possible to allow different stack trace formatters per each `PatternFormatter`, but this would require extra logic and configuration which would need to be thought out somehow.
* This kind of functionality would be necessary to support something like https://github.com/quarkusio/quarkus/issues/37002