### PR TITLE
[LOGMGR-347] Do not use deprecated SmallRye Common OS `Process`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <description>An implementation of java.util.logging.LogManager</description>
     <groupId>org.jboss.logmanager</groupId>
     <artifactId>jboss-logmanager</artifactId>
-    <version>3.0.5.Final-SNAPSHOT</version>
+    <version>3.1.0.Final-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/org/jboss/logmanager/ExtLogRecord.java
+++ b/src/main/java/org/jboss/logmanager/ExtLogRecord.java
@@ -19,6 +19,8 @@
 
 package org.jboss.logmanager;
 
+import static java.security.AccessController.doPrivileged;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -26,6 +28,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.security.PrivilegedAction;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.MissingResourceException;
@@ -108,7 +111,7 @@ public class ExtLogRecord extends LogRecord {
         longThreadID = Thread.currentThread().getId(); // todo: threadId() on 19+
         hostName = HostName.getQualifiedHostName();
         processName = io.smallrye.common.os.Process.getProcessName();
-        processId = io.smallrye.common.os.Process.getProcessId();
+        processId = doPrivileged((PrivilegedAction<ProcessHandle>) ProcessHandle::current).pid();
     }
 
     /**


### PR DESCRIPTION
See smallrye/smallrye-common#299. Prevents caching of process ID across native image (where the PID may change).

Also removes PID cache from the syslog handler.