### PR TITLE
[LOGMGR-351] Fix periodic file rotation by week, month, year.

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/PeriodicRotatingFileHandler.java
@@ -29,6 +29,7 @@ import java.security.PrivilegedAction;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.TimeZone;
 import java.util.logging.ErrorManager;
@@ -248,13 +249,13 @@ public class PeriodicRotatingFileHandler extends FileHandler {
         switch (period) {
             default:
             case YEAR:
-                zdt = zdt.truncatedTo(ChronoUnit.YEARS).plusYears(1);
+                zdt = zdt.withDayOfYear(1).truncatedTo(ChronoUnit.DAYS).plusYears(1);
                 break;
             case MONTH:
-                zdt = zdt.truncatedTo(ChronoUnit.MONTHS).plusYears(1);
+                zdt = zdt.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS).plusMonths(1);
                 break;
             case WEEK:
-                zdt = zdt.truncatedTo(ChronoUnit.WEEKS).plusWeeks(1);
+                zdt = zdt.with(ChronoField.DAY_OF_WEEK, 1).truncatedTo(ChronoUnit.DAYS).plusWeeks(1);
                 break;
             case DAY:
                 zdt = zdt.truncatedTo(ChronoUnit.DAYS).plusDays(1);


### PR DESCRIPTION
It is not possible to use rotation periods longer then DAYS, because java.time.ZonedDateTime#truncatedTo throws an exception for such periods.
```
java.time.temporal.UnsupportedTemporalTypeException: Unit is too large to be used for truncation
```
Hopefully, this PR is fixing the problem.