### PR TITLE
[LOGMGR-350] Avoid TCCL when configuring the log manager

### DIFF
--- a/src/main/java/org/jboss/logmanager/LogManager.java
+++ b/src/main/java/org/jboss/logmanager/LogManager.java
@@ -117,7 +117,8 @@ public final class LogManager extends java.util.logging.LogManager {
                 if (configurator == null) {
                     int best = Integer.MAX_VALUE;
                     ConfiguratorFactory factory = null;
-                    final ServiceLoader<ConfiguratorFactory> serviceLoader = ServiceLoader.load(ConfiguratorFactory.class);
+                    final ServiceLoader<ConfiguratorFactory> serviceLoader = ServiceLoader.load(ConfiguratorFactory.class,
+                            LogManager.class.getClassLoader());
                     final Iterator<ConfiguratorFactory> iterator = serviceLoader.iterator();
                     List<Throwable> problems = null;
                     for (;;)

--- a/src/main/java/org/jboss/logmanager/configuration/PropertyLogContextConfigurator.java
+++ b/src/main/java/org/jboss/logmanager/configuration/PropertyLogContextConfigurator.java
@@ -77,7 +77,8 @@ public class PropertyLogContextConfigurator implements LogContextConfigurator {
             context.attachIfAbsent(ContextConfiguration.CONTEXT_CONFIGURATION_KEY, configurator);
         } else {
             // Next check the service loader
-            final Iterator<LogContextConfigurator> serviceLoader = ServiceLoader.load(LogContextConfigurator.class).iterator();
+            final Iterator<LogContextConfigurator> serviceLoader = ServiceLoader
+                    .load(LogContextConfigurator.class, PropertyLogContextConfigurator.class.getClassLoader()).iterator();
             if (serviceLoader.hasNext()) {
                 serviceLoader.next().configure(context, null);
             } else {
@@ -95,20 +96,18 @@ public class PropertyLogContextConfigurator implements LogContextConfigurator {
 
     private static InputStream findConfiguration() {
         final String propLoc = System.getProperty("logging.configuration");
-        if (propLoc != null)
+        if (propLoc != null) {
             try {
                 return new URL(propLoc).openStream();
             } catch (IOException e) {
                 StandardOutputStreams.printError("Unable to read the logging configuration from '%s' (%s)%n", propLoc, e);
             }
-        final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-        if (tccl != null)
-            try {
-                final InputStream stream = tccl.getResourceAsStream("logging.properties");
-                if (stream != null)
-                    return stream;
-            } catch (Exception ignore) {
-            }
-        return PropertyLogContextConfigurator.class.getResourceAsStream("logging.properties");
+        }
+        final ClassLoader cl = PropertyLogContextConfigurator.class.getClassLoader();
+        try {
+            return cl.getResourceAsStream("logging.properties");
+        } catch (Exception ignore) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
The services were previously located by looking at the TCCL rather than class loader which loaded the log manager itself. This is normally the system (i.e. application) class loader, but it could be an agent class loader or the bootstrap class loader in certain circumstances.

One result of this behavior is that when the TCCL is not the same as the system class loader, logging can be configured twice: once by Quarkus and once using the default configuration (see https://github.com/elastic/apm-agent-java/issues/3563). Changing to avoid the TCCL causes the behavior to become stable and predictable.