### PR TITLE
[LOGMGR-353] Upgrade byteman to 4.0.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <properties>
         <!-- Dependency versions -->
         <version.jakarta.json>1.1.6</version.jakarta.json>
-        <version.org.byteman>4.0.17</version.org.byteman>
+        <version.org.byteman>4.0.22</version.org.byteman>
         <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
         <version.org.jboss.modules.jboss-modules>1.9.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.wildfly.common.wildfly-common>1.5.1.Final</version.org.wildfly.common.wildfly-common>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/LOGMGR-353
JBEAP issue: https://issues.redhat.com/browse/JBEAP-28021

Upgrade byteman to 4.0.22 fixes the failing `PeriodicRotatingFileHandlerTests` on JDK 21. 

`4.0.22` is also the version in `main` branch