### PR TITLE
Save head encoding on sanitized String(s)

### DIFF
--- a/src/main/java/org/jboss/logmanager/formatters/TextBannerFormatter.java
+++ b/src/main/java/org/jboss/logmanager/formatters/TextBannerFormatter.java
@@ -37,7 +37,9 @@ public final class TextBannerFormatter extends ExtFormatter.Delegating {
     public String getHead(final Handler h) {
         final String dh = Objects.requireNonNullElse(delegate.getHead(h), "");
         final String banner = Objects.requireNonNullElse(bannerSupplier.get(), "");
-        return banner + dh;
+        // it doesn't use + because dh can be empty and we both don't want to create an indy and
+        // we don't want to create a new string
+        return banner.concat(dh);
     }
 
     /**

--- a/src/main/java/org/jboss/logmanager/handlers/OutputStreamHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/OutputStreamHandler.java
@@ -79,15 +79,6 @@ public class OutputStreamHandler extends WriterHandler {
         }
     }
 
-    public Charset getCharset() {
-        lock.lock();
-        try {
-            return super.getCharset();
-        } finally {
-            lock.unlock();
-        }
-    }
-
     /** {@inheritDoc} Setting a writer will replace any target output stream. */
     public void setWriter(final Writer writer) {
         lock.lock();

--- a/src/main/java/org/jboss/logmanager/handlers/WriterHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/WriterHandler.java
@@ -23,6 +23,8 @@ import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.ErrorManager;
 import java.util.logging.Formatter;
 
@@ -175,9 +177,11 @@ public class WriterHandler extends ExtHandler {
             final Formatter formatter = getFormatter();
             if (formatter != null) {
                 final String head = formatter.getHead(this);
-                if (checkHeadEncoding) {
-                    if (!getCharset().newEncoder().canEncode(head)) {
-                        reportError("Section header cannot be encoded into charset \"" + getCharset().name() + "\"", null,
+                if (!head.isEmpty() && checkHeadEncoding) {
+                    Charset cs = getCharset();
+                    // UTF-8 is always safe since the UTF-16 chars in String(s) are always encodable
+                    if (!StandardCharsets.UTF_8.equals(cs) && cs.newEncoder().canEncode(head)) {
+                        reportError("Section header cannot be encoded into charset \"" + cs.name() + "\"", null,
                                 ErrorManager.GENERIC_FAILURE);
                         return;
                     }


### PR DESCRIPTION
In theory not just UTF-8, but UTF-16 as well is not needed to be checked (see https://stackoverflow.com/a/75072043)

Right now it seems `getCharset` is guarded by a lock despite being volatile; which is happening in the hot path and we could avoid it.

I've added another change to avoid string concat for a pretty common case i.e. empty head.

