### PR TITLE
Add smart service provider method

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -29,7 +29,7 @@ module org.jboss.logmanager {
     exports org.jboss.logmanager.formatters;
     exports org.jboss.logmanager.handlers;
 
-    provides java.util.logging.LogManager with LogManager;
+    provides java.util.logging.LogManager with LogManager.Provider;
     provides System.LoggerFinder with JBossLoggerFinder;
     provides ConfiguratorFactory with DefaultConfiguratorFactory;
 

--- a/src/main/java/org/jboss/logmanager/LogManager.java
+++ b/src/main/java/org/jboss/logmanager/LogManager.java
@@ -222,4 +222,25 @@ public final class LogManager extends java.util.logging.LogManager {
     public Logger getLogger(String name) {
         return LogContext.getLogContext().getLogger(name);
     }
+
+    public static final class Provider {
+        /**
+         * The service provider method.
+         * This method is used when the log manager service is loaded from a modular application.
+         *
+         * @return the log manager instance (not {@code null})
+         * @throws ClassCastException if the log manager is not initialized to this class
+         */
+        public static LogManager provider() {
+            Thread ct = Thread.currentThread();
+            ClassLoader old = ct.getContextClassLoader();
+            ct.setContextClassLoader(Provider.class.getClassLoader());
+            try {
+                System.setProperty("java.util.logging.manager", LogManager.class.getName());
+                return (LogManager) getLogManager();
+            } finally {
+                ct.setContextClassLoader(old);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This allows a service loader to fully initialize the log manager without worrying about class init loops.

Note that security manager support is not needed, because these methods cannot be used on any downstream project for which security managers are supported.