### PR TITLE
Do not generate service file for LogManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,13 +302,19 @@
             <plugin>
                 <groupId>io.github.dmlloyd.maven</groupId>
                 <artifactId>module-services-plugin</artifactId>
-                <version>1.0</version>
+                <version>1.1</version>
                 <executions>
                     <execution>
                         <id>generate-services</id>
                         <goals>
                             <goal>generate</goal>
                         </goals>
+                        <configuration>
+                            <excludeServices>
+                                <!-- Modular impl is different from non-modular impl -->
+                                <excludeService>java.util.logging.LogManager</excludeService>
+                            </excludeServices>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/resources/META-INF/services/java.util.logging.LogManager
+++ b/src/main/resources/META-INF/services/java.util.logging.LogManager
@@ -1,0 +1,2 @@
+# In class path mode, we use LogManager itself; in module mode we use LogManager.Provider instead
+org.jboss.logmanager.LogManager


### PR DESCRIPTION
In module mode, we want to use the `Provider` nested class. In class path mode, we do not.