### PR TITLE
Add a getter for target in ConsoleHandler

### DIFF
--- a/src/main/java/org/jboss/logmanager/handlers/ConsoleHandler.java
+++ b/src/main/java/org/jboss/logmanager/handlers/ConsoleHandler.java
@@ -62,6 +62,7 @@ public class ConsoleHandler extends OutputStreamHandler {
         CONSOLE,
     }
 
+    private volatile Target target;
     private final ErrorManager localErrorManager = new HandlerErrorManager(this);
 
     /**
@@ -98,6 +99,7 @@ public class ConsoleHandler extends OutputStreamHandler {
     public ConsoleHandler(final Target target, final Formatter formatter) {
         super(formatter);
         setCharset(JDKSpecific.consoleCharset());
+        this.target = target;
         switch (target) {
             case SYSTEM_OUT:
                 setOutputStream(wrap(out));
@@ -120,6 +122,7 @@ public class ConsoleHandler extends OutputStreamHandler {
      */
     public void setTarget(Target target) {
         final Target t = (target == null ? defaultTarget() : target);
+        this.target = t;
         switch (t) {
             case SYSTEM_OUT:
                 setOutputStream(wrap(out));
@@ -133,6 +136,15 @@ public class ConsoleHandler extends OutputStreamHandler {
             default:
                 throw new IllegalArgumentException();
         }
+    }
+
+    /**
+     * Get the target for this console handler.
+     *
+     * @return the target (not {@code null})
+     */
+    public Target getTarget() {
+        return target;
     }
 
     public void setErrorManager(final ErrorManager em) {

--- a/src/test/java/org/jboss/logmanager/handlers/ConsoleHandlerTests.java
+++ b/src/test/java/org/jboss/logmanager/handlers/ConsoleHandlerTests.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logmanager.handlers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+
+public class ConsoleHandlerTests {
+
+    @Test
+    public void testDefaultTarget() {
+        final ConsoleHandler handler = new ConsoleHandler();
+        final ConsoleHandler.Target target = handler.getTarget();
+        assertNotNull(target);
+        // Default should be CONSOLE if a console exists, SYSTEM_OUT otherwise
+        if (ConsoleHandler.hasConsole()) {
+            assertEquals(ConsoleHandler.Target.CONSOLE, target);
+        } else {
+            assertEquals(ConsoleHandler.Target.SYSTEM_OUT, target);
+        }
+    }
+
+    @Test
+    public void testConstructorWithTarget() {
+        final ConsoleHandler handler = new ConsoleHandler(ConsoleHandler.Target.SYSTEM_ERR);
+        assertEquals(ConsoleHandler.Target.SYSTEM_ERR, handler.getTarget());
+    }
+
+    @Test
+    public void testConstructorWithTargetAndFormatter() {
+        final ConsoleHandler handler = new ConsoleHandler(ConsoleHandler.Target.SYSTEM_OUT, new PatternFormatter("%m"));
+        assertEquals(ConsoleHandler.Target.SYSTEM_OUT, handler.getTarget());
+    }
+
+    @Test
+    public void testSetTarget() {
+        final ConsoleHandler handler = new ConsoleHandler(ConsoleHandler.Target.SYSTEM_OUT);
+        assertEquals(ConsoleHandler.Target.SYSTEM_OUT, handler.getTarget());
+
+        handler.setTarget(ConsoleHandler.Target.SYSTEM_ERR);
+        assertEquals(ConsoleHandler.Target.SYSTEM_ERR, handler.getTarget());
+
+        handler.setTarget(ConsoleHandler.Target.SYSTEM_OUT);
+        assertEquals(ConsoleHandler.Target.SYSTEM_OUT, handler.getTarget());
+    }
+
+    @Test
+    public void testSetTargetNull() {
+        final ConsoleHandler handler = new ConsoleHandler(ConsoleHandler.Target.SYSTEM_ERR);
+        handler.setTarget(null);
+        // null defaults to the default target
+        if (ConsoleHandler.hasConsole()) {
+            assertEquals(ConsoleHandler.Target.CONSOLE, handler.getTarget());
+        } else {
+            assertEquals(ConsoleHandler.Target.SYSTEM_OUT, handler.getTarget());
+        }
+    }
+}


### PR DESCRIPTION
I'm working on a patch in Quarkus that would need to be able to capture the original target so that it can restored after.

Not being able to access the value is a problem.

@dmlloyd @jamezp if this appears good to you, I would appreciate a quick merge and release as it makes a patch I'm working on to fix https://github.com/quarkusio/quarkus/issues/54575 unnecessarily complicated.